### PR TITLE
exclude inhalers not used for asthma/copd in green inhaler measure

### DIFF
--- a/viewer/measures/green_inhalers.sql
+++ b/viewer/measures/green_inhalers.sql
@@ -26,3 +26,13 @@ WHERE ofr.name IN (
     'powderinhalation.inhalation',
     'inhalationsolution.inhalation'
 )
+AND vmp.code NOT IN (
+    '32687711000001109',  -- Loxapine 9.1mg/dose inhalation powder
+    '22555311000001104',  -- Colistimethate 1,662,500unit inhalation powder capsules
+    '15426411000001107',  -- Mannitol 40mg inhalation powder capsules
+    '20514511000001105',  -- Mannitol 40mg inhalation powder capsules with device
+    '20515111000001102',  -- Mannitol 40mg inhalation powder capsules with two devices
+    '39488111000001102',  -- Pentetic acid 20.8mg kit for radiopharmaceutical preparation
+    '19544811000001101',  -- Tobramycin 28mg inhalation powder capsules
+    '36151011000001106'   -- Zanamivir 5mg inhalation powder blisters with device
+)


### PR DESCRIPTION
Removes the inhalers listed in #178 from the green inhalers measure