### PR TITLE
add tooltip for total mode

### DIFF
--- a/src/components/common/ModeSelector.svelte
+++ b/src/components/common/ModeSelector.svelte
@@ -7,6 +7,8 @@
   export let onChange = () => {};
   export let variant = 'dropdown';
 
+  const totalTooltipText = 'Monthly quantity across all selected products and NHS Trusts';
+
   $: {
     modeSelectorStore.setOptions(options);
     if (initialMode && !$modeSelectorStore.selectedMode) {
@@ -37,7 +39,12 @@
       value={$modeSelectorStore.selectedMode}
     >
       {#each $modeSelectorStore.options as option}
-        <option value={option.value}>{option.label}</option>
+        <option 
+          value={option.value}
+          title={option.value === 'total' ? totalTooltipText : ''}
+        >
+          {option.label}
+        </option>
       {/each}
     </select>
   </div>
@@ -47,15 +54,27 @@
       <label class="block text-sm font-medium text-gray-700 mb-2">{label}</label>
       <div class="flex flex-wrap gap-2">
         {#each $modeSelectorStore.options as option}
-          <button
-            class="px-3 py-1 rounded-full text-sm font-medium transition-colors
-              {$modeSelectorStore.selectedMode === option.value
-                ? 'bg-oxford-600 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}"
-            on:click={() => handlePillClick(option.value)}
-          >
-            {option.label}
-          </button>
+          <div class="relative inline-block group">
+            <button
+              class="px-3 py-1 rounded-full text-sm font-medium transition-colors
+                {$modeSelectorStore.selectedMode === option.value
+                  ? 'bg-oxford-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}"
+              on:click={() => handlePillClick(option.value)}
+            >
+              {option.label}
+            </button>
+            {#if option.value === 'total'}
+              <div class="absolute z-10 scale-0 transition-all duration-100 origin-top transform 
+                          group-hover:scale-100 w-[200px] left-0 top-full mt-1
+                          rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 p-4
+                          max-w-[calc(100vw-2rem)]">
+                <p class="text-sm text-gray-500">
+                  {totalTooltipText}
+                </p>
+              </div>
+            {/if}
+          </div>
         {/each}
       </div>
     {/if}


### PR DESCRIPTION
Adds a tooltip for "Total" mode in the analysis results chart. This will make it more obvious what total means here.

Resolves #92