### PR TITLE
add product to vmp unit standardisation

### DIFF
--- a/pipeline/flows/import_vmp_unit_standardisation.py
+++ b/pipeline/flows/import_vmp_unit_standardisation.py
@@ -246,6 +246,18 @@ def create_standardisation_dict() -> Dict[str, UnitStandardisation]:
             conversion_logic="1 bag = 1 litre",
             conversion_factor=1
         ),
+        "9062611000001102": UnitStandardisation(
+            vmp_code="9062611000001102",
+            vmp_name="Citric acid 1g/10ml oral solution unit dose sugar free",
+            scmd_units=[
+                {"unit_id": "733013000", "unit_name": "sachet"},
+                {"unit_id": "258773002", "unit_name": "ml"}
+            ],
+            chosen_unit_id="258773002",
+            chosen_unit_name="ml",
+            conversion_logic="1 sachet = 10 ml",
+            conversion_factor=10
+        ),
     }
     
     return standardisations


### PR DESCRIPTION
Adds `Citric acid 1g/10ml oral solution unit dose sugar free` to the vmp unit standardisation table. This was introduced when the data between Jan 2019-March 2019 was introduced in #352 - for these months, usage was reported in sachets not ml