### PR TITLE
Don't use DDDs with comments

### DIFF
--- a/pipeline/sql/create_vmp_ddd_mapping.sql
+++ b/pipeline/sql/create_vmp_ddd_mapping.sql
@@ -183,7 +183,8 @@ ddd_route_selection AS (
       WHEN ARRAY_LENGTH(matching_route_ddds) = 0 THEN FALSE
       WHEN NOT all_matching_ddds_same THEN FALSE
       WHEN (SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1) IS NOT NULL 
-        AND TRIM((SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1)) != '' THEN FALSE
+        AND TRIM((SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1)) != '' 
+        AND TRIM((SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1)) != 'New DDD' THEN FALSE
       ELSE TRUE
     END AS route_match_ok,
     CASE
@@ -194,7 +195,8 @@ ddd_route_selection AS (
       WHEN NOT all_matching_ddds_same THEN 'Multiple different DDD values for matching routes'
       WHEN (SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1) IS NOT NULL 
         AND TRIM((SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1)) != '' 
-        THEN CONCAT('DDD has comment: ', (SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1))
+        AND TRIM((SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1)) != 'New DDD'
+        THEN CONCAT('DDD has unsupported comment: ', (SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1))
       ELSE NULL
     END AS route_matching_issue,
     -- Get the selected DDD when routes match

--- a/pipeline/sql/create_vmp_ddd_mapping.sql
+++ b/pipeline/sql/create_vmp_ddd_mapping.sql
@@ -171,13 +171,19 @@ ddd_analysis AS (
 ddd_route_selection AS (
   SELECT
     da.*,
-    -- Route matching checks
+    CASE
+      WHEN NOT has_atc_codes OR NOT has_ddds OR NOT has_who_routes OR ARRAY_LENGTH(matching_route_ddds) = 0 OR NOT all_matching_ddds_same THEN NULL
+      ELSE (SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1)
+    END AS selected_ddd_comment,
+    -- Route matching checks. Also check if the DDD has a comment. If it does, then the route match is not ok.
     CASE
       WHEN NOT has_atc_codes THEN FALSE
       WHEN NOT has_ddds THEN FALSE
       WHEN NOT has_who_routes THEN FALSE
       WHEN ARRAY_LENGTH(matching_route_ddds) = 0 THEN FALSE
       WHEN NOT all_matching_ddds_same THEN FALSE
+      WHEN (SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1) IS NOT NULL 
+        AND TRIM((SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1)) != '' THEN FALSE
       ELSE TRUE
     END AS route_match_ok,
     CASE
@@ -186,6 +192,9 @@ ddd_route_selection AS (
       WHEN NOT has_who_routes THEN 'No WHO routes mapped'
       WHEN ARRAY_LENGTH(matching_route_ddds) = 0 THEN 'No matching routes between VMP and DDD values'
       WHEN NOT all_matching_ddds_same THEN 'Multiple different DDD values for matching routes'
+      WHEN (SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1) IS NOT NULL 
+        AND TRIM((SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1)) != '' 
+        THEN CONCAT('DDD has comment: ', (SELECT ddd_comment FROM UNNEST(matching_route_ddds) LIMIT 1))
       ELSE NULL
     END AS route_matching_issue,
     -- Get the selected DDD when routes match


### PR DESCRIPTION
Some DDDs have comments associated with them. They need more thought before they can be used to calculate DDD quantity. One exception is comments that indicate a New DDD, taken from the alterations information - no special treatment is needed for these