### PR TITLE
Fix missing DDD values and calculation logic

### DIFF
--- a/pipeline/flows/import_atc.py
+++ b/pipeline/flows/import_atc.py
@@ -200,12 +200,11 @@ def process_atc_data(
         if alterations_comment and alterations_comment.strip():
             comments.append(alterations_comment.strip())
         
-        # Add default comment if no alterations comment
-        if not alterations_comment or not alterations_comment.strip():
-            comments.append(default_comment)
+        if not comments:
+            return None
         
         final_comment = '; '.join(comments)
-        return None if not final_comment else final_comment.strip()
+        return final_comment.strip() if final_comment else None
     
     # Delete codes
     deletions_made = 0
@@ -229,7 +228,7 @@ def process_atc_data(
         new_rows.append({
             'atc_code': code,
             'atc_name': substance,
-            'comment': alterations_comment if alterations_comment else 'Added from alterations table'
+            'comment': alterations_comment if alterations_comment and alterations_comment.strip() else None
         })
     
     if new_rows:

--- a/pipeline/flows/import_ddd.py
+++ b/pipeline/flows/import_ddd.py
@@ -101,7 +101,7 @@ def create_ddd_mappings(ddd_alterations: pd.DataFrame) -> Tuple[Dict, List[Dict]
                     'ddd': float(new_ddd),
                     'ddd_unit': new_unit.lower(),
                     'adm_code': route,
-                    'comment': alterations_comment if alterations_comment else 'Added from alterations table'
+                    'comment': alterations_comment if alterations_comment and alterations_comment.strip() else None
                 })
             continue
             
@@ -147,11 +147,14 @@ def apply_ddd_deletions_and_updates(ddd_df: pd.DataFrame, ddd_updates: Dict, ddd
         if alterations_comment and alterations_comment.strip():
             comments.append(alterations_comment.strip())
         
-        # Add the update note
-        comments.append(f"Updated from alterations table (changed in {year_changed})")
+        if alterations_comment and alterations_comment.strip():
+            comments.append(f"Updated from alterations table (changed in {year_changed})")
+        
+        if not comments:
+            return None
         
         final_comment = '; '.join(comments)
-        return None if not final_comment else final_comment.strip()
+        return final_comment.strip() if final_comment else None
     
     for atc_code, route in ddds_to_delete:
         mask = (


### PR DESCRIPTION
When importing ATC and DDD alterations, a comment was being added to indicate an alteration. This meant that DDD quantity wasn't being calculated for any products with alterations, because we currently ignore any products with comments, which indicate peculiarities about the DDD. This removes the default comment so only actual comments are included.

Also updates the loading of calculation logic for ingredient quantity and DDD quantity. Calculation logic wasn't being loaded for products where the quantity couldn't be calculated because we restricted the data to vmps where the quantity exists. This splits out the loading of the calculation logic, which we need for all products, from the quantity information which is only available for some. 