### PR TITLE
drop login from nav

### DIFF
--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -138,17 +138,8 @@
                   </button>
                 </form>
               </li>
-            {% else %}
-              <li>
-                <a class="
-                  relative inline-flex h-full items-center text-oxford transition-colors duration-200 rounded px-2 py-2 -ml-2
-                  hover:text-bn-strawberry-700
-                  focus:text-bn-strawberry-700 focus:outline-none focus:ring-2 focus:ring-oxford-500
-                " href="{% url 'viewer:login' %}">
-                  Login
-                </a>
-              </li>
             {% endif %}
+            
             <li class="mt-4 border-t border-gray-100 pt-4">
               <button type="button" class="
                 relative border border-oxford/25 rounded p-2 transition-colors text-oxford duration-200
@@ -269,11 +260,6 @@
               Logout
             </button>
           </form>
-          {% else %}
-          <a href="{% url 'viewer:login' %}" class="block px-4 py-2 text-oxford hover:text-bn-strawberry-700 hover:bg-slate-50
-            focus:outline-none focus:text-bn-strawberry-700 focus:bg-slate-50">
-            Login
-          </a>
           {% endif %}
         </div>
       </li>


### PR DESCRIPTION
We have a login for testing some features internally. You don't need one to access any of the main features - removing the link from the nav makes that more obvious