### PR TITLE
Set analyse modes based on trust selection

### DIFF
--- a/src/components/analyse/analyse/AnalysisBuilder.svelte
+++ b/src/components/analyse/analyse/AnalysisBuilder.svelte
@@ -315,13 +315,23 @@
                   </svg>
                 </button>
                 <div class="absolute z-10 scale-0 transition-all duration-100 origin-top transform 
-                            group-hover:scale-100 w-[250px] -translate-x-[85%] left-1/2 top-5 rounded-md shadow-lg bg-white  
-                            ring-1 ring-black ring-opacity-5 p-4">
-                  <p class="text-sm text-gray-500">
-                    Select up to 10 NHS Trusts to see their individual usage.
-                    See <a href="/faq/#which-nhs-trusts-are-included" class="underline font-semibold" target="_blank">the FAQs</a> for more details 
-                    on which trusts are included.
-                  </p>
+                  group-hover:scale-100 w-[300px] -translate-x-[85%] left-1/2 top-5 rounded-md shadow-lg bg-white  
+                  ring-1 ring-black ring-opacity-5 p-4">
+                  <div class="text-sm text-gray-500 space-y-3">
+                    <div class="space-y-1 text-xs">
+                      <p>Select up to 10 NHS Trusts.</p>
+                      <ul>
+                        <li><strong>No trusts selected:</strong> Shows national data with regional/ICB breakdowns available</li>
+                        <li><strong>Trusts selected:</strong> Filters analysis results to the selected trusts</li>
+                      </ul>
+                    </div>
+                    <div>
+                      <p class="text-xs">
+                        See <a href="/faq/#how-do-i-see-icb-regional-and-national-breakdowns" class="underline font-semibold" target="_blank">the FAQs</a> for more details
+                        of how trust selection affects analysis modes and <a href="/faq/#which-nhs-trusts-are-included" class="underline font-semibold" target="_blank">which trusts are included</a>.
+                      </p>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/components/analyse/results/TotalsTable.svelte
+++ b/src/components/analyse/results/TotalsTable.svelte
@@ -9,7 +9,7 @@
     import { resultsStore } from '../../../stores/resultsStore';
     import { organisationSearchStore } from '../../../stores/organisationSearchStore';
     import { formatNumber } from '../../../utils/utils';
-    import { processTableDataByMode, getModeDisplayName } from '../../../utils/analyseUtils';
+    import { processTableDataByMode, getModeDisplayName, getTableExplainerText } from '../../../utils/analyseUtils';
 
     export let data = [];
     export let quantityType = 'SCMD Quantity';
@@ -64,6 +64,25 @@
     $: titleText = selectedMode === 'national' 
         ? 'National total' 
         : `Total quantity by ${getModeDisplayName(selectedMode)}`;
+
+    $: hasSelectedTrusts = $analyseOptions.selectedOrganisations && $analyseOptions.selectedOrganisations.length > 0;
+    
+    $: quantityColumnHeader = (() => {
+        if (hasSelectedTrusts && selectedMode !== 'organisation') {
+            return 'Quantity (selected trusts)';
+        } else {
+            return 'Quantity';
+        }
+    })();
+
+    $: tableExplainerText = getTableExplainerText(selectedMode, {
+        hasSelectedTrusts: hasSelectedTrusts,
+        selectedTrustsCount: $analyseOptions.selectedOrganisations?.length || 0,
+        selectedPeriod: selectedPeriod,
+        latestMonth: latestMonth,
+        latestYear: latestYear,
+        dateRange: dateRange
+    });
 
     function toggleTrustExpansion(trustName) {
         if (expandedTrusts.has(trustName)) {
@@ -137,6 +156,13 @@
             </div>
         </div>
     </div>
+    
+    <div class="mb-4">
+        <p class="text-sm text-gray-700">
+            {tableExplainerText}
+        </p>
+    </div>
+    
     <div class="overflow-x-auto">
         <div class="max-h-96 overflow-y-auto relative">
             <table class="min-w-full bg-white border border-gray-300 shadow-sm rounded-lg overflow-hidden">
@@ -150,7 +176,9 @@
                         {#if selectedMode !== 'unit'}
                             <th class="py-3 px-6 text-left">Unit</th>
                         {/if}
-                        <th class="py-3 px-6 text-right">Quantity</th>
+                        <th class="py-3 px-6 text-right">
+                            {quantityColumnHeader}
+                        </th>
                     </tr>
                 </thead>
                 <tbody class="text-gray-600 text-sm">
@@ -169,7 +197,7 @@
                             </tr>
                         {:else if quantityType === 'DDD'}
                             <tr class="border-b border-gray-200 hover:bg-gray-100 
-                                {group.isSubtotal ? 'bg-blue-50 font-semibold' : ''} 
+                                {group.isSubtotal ? (group.section === 'selected' ? 'bg-green-50 font-semibold' : 'bg-blue-50 font-semibold') : ''} 
                                 {group.isPredecessor ? 'bg-gray-50' : ''}">
                                 {#if selectedMode !== 'national'}
                                     <td class="py-3 px-6 text-left {group.isPredecessor ? 'pl-16' : ''}">
@@ -208,9 +236,9 @@
                                     {formatNumber(group.total)}
                                 </td>
                             </tr>
-                        {:else if !$analyseOptions.isAdvancedMode || group.units.length === 1}
+                        {:else if group.units.length === 1}
                             <tr class="border-b border-gray-200 hover:bg-gray-100 
-                                {group.isSubtotal ? 'bg-blue-50 font-semibold' : ''} 
+                                {group.isSubtotal ? (group.section === 'selected' ? 'bg-green-50 font-semibold' : 'bg-blue-50 font-semibold') : ''} 
                                 {group.isPredecessor ? 'bg-gray-50' : ''}">
                                 {#if selectedMode !== 'national'}
                                     <td class="py-3 px-6 text-left {group.isPredecessor ? 'pl-16' : ''}">
@@ -251,7 +279,7 @@
                             </tr>
                         {:else}
                             <tr class="border-b border-gray-200 hover:bg-gray-100 font-bold 
-                                {group.isSubtotal ? 'bg-blue-50 font-semibold' : ''} 
+                                {group.isSubtotal ? (group.section === 'selected' ? 'bg-green-50 font-semibold' : 'bg-blue-50 font-semibold') : ''} 
                                 {group.isPredecessor ? 'bg-gray-50' : ''}">
                                 {#if selectedMode !== 'national'}
                                     <td class="py-3 px-6 text-left {group.isPredecessor ? 'pl-16' : ''}" 

--- a/src/utils/analyseUtils.js
+++ b/src/utils/analyseUtils.js
@@ -459,6 +459,11 @@ export class ViewModeCalculator {
     getAggregationModes() {
         const modes = [];
         
+        // Only show aggregation modes if no trusts are selected
+        if (this.hasSelectedOrganisations()) {
+            return modes;
+        }
+        
         if (!this.resultsStore.aggregatedData) return modes;
         
         const { regions = {}, icbs = {}, national = {} } = this.resultsStore.aggregatedData;

--- a/src/utils/analyseUtils.js
+++ b/src/utils/analyseUtils.js
@@ -255,8 +255,13 @@ export class ChartDataProcessor {
 
     processProductMode() {
         const productData = {};
+        const selectedOrganisations = this.options.selectedOrganisations || [];
         
-        this.rawData.forEach(item => {
+        const dataToUse = selectedOrganisations.length > 0 ? 
+            this.rawData.filter(item => selectedOrganisations.includes(item.organisation__ods_name)) : 
+            this.rawData;
+        
+        dataToUse.forEach(item => {
             if (item.vmp__code && item.data) {
                 const productKey = item.vmp__code;
                 const productName = item.vmp__name;
@@ -277,8 +282,13 @@ export class ChartDataProcessor {
 
     processProductGroupMode() {
         const vtmGroups = {};
+        const selectedOrganisations = this.options.selectedOrganisations || [];
         
-        this.rawData.forEach(item => {
+        const dataToUse = selectedOrganisations.length > 0 ? 
+            this.rawData.filter(item => selectedOrganisations.includes(item.organisation__ods_name)) : 
+            this.rawData;
+        
+        dataToUse.forEach(item => {
             if (item.vmp__vtm__name && item.data) {
                 const vtm = item.vmp__vtm__name || item.vtm__name || 'Unknown';
                 
@@ -298,8 +308,13 @@ export class ChartDataProcessor {
 
     processUnitMode() {
         const unitData = {};
+        const selectedOrganisations = this.options.selectedOrganisations || [];
         
-        this.rawData.forEach(item => {
+        const dataToUse = selectedOrganisations.length > 0 ? 
+            this.rawData.filter(item => selectedOrganisations.includes(item.organisation__ods_name)) : 
+            this.rawData;
+        
+        dataToUse.forEach(item => {
             if (item.data) {
                 item.data.forEach(([date, value, unit]) => {
                     if (!unit) return;
@@ -326,8 +341,13 @@ export class ChartDataProcessor {
 
     processIngredientMode() {
         const ingredientData = {};
+        const selectedOrganisations = this.options.selectedOrganisations || [];
+
+        const dataToUse = selectedOrganisations.length > 0 ? 
+            this.rawData.filter(item => selectedOrganisations.includes(item.organisation__ods_name)) : 
+            this.rawData;
         
-        this.rawData.forEach(item => {
+        dataToUse.forEach(item => {
             if (item.ingredient_names && item.data) {
                 const ingredients = item.ingredient_names || ['Unknown'];
                 ingredients.forEach(ingredient => {
@@ -739,7 +759,7 @@ export function processTableDataByMode(data, mode, period, aggregatedData, lates
         return processOrganisationModeWithAggregation(data, period, latestDate, selectedOrganisations, allOrganisations, predecessorMap, expandedTrusts);
     }
 
-    return processRawDataMode(data, mode, period, latestDate);
+    return processRawDataMode(data, mode, period, latestDate, selectedOrganisations);
 }
 
 function processOrganisationModeWithAggregation(data, period, latestDate, selectedOrganisations, allOrganisations, predecessorMap, expandedTrusts) {
@@ -1003,7 +1023,7 @@ function processAggregatedMode(aggregatedData, mode, period, latestDate) {
     return results.sort((a, b) => b.total - a.total);
 }
 
-function processRawDataMode(data, mode, period, latestDate) {
+function processRawDataMode(data, mode, period, latestDate, selectedOrganisations = []) {
     if (!data?.length) return [];
 
     const filteredData = data.map(item => ({
@@ -1012,9 +1032,13 @@ function processRawDataMode(data, mode, period, latestDate) {
             shouldIncludeDate(date, period, latestDate)) : []
     }));
 
+    const dataToProcess = selectedOrganisations.length > 0 
+        ? filteredData.filter(item => selectedOrganisations.includes(item.organisation__ods_name))
+        : filteredData;
+
     const groupedData = {};
 
-    filteredData.forEach(item => {
+    dataToProcess.forEach(item => {
         const groupKey = getGroupKey(item, mode);
         
         if (Array.isArray(groupKey)) {
@@ -1087,55 +1111,64 @@ export function getModeDisplayName(mode) {
 }
 
 export function getChartExplainerText(mode, options = {}) {
-    const { 
-        hasSelectedOrganisations = false, 
-        currentModeHasData = true,
-        vmpsCount = 0
-    } = options;
+    const { hasSelectedOrganisations = false, currentModeHasData = true, vmpsCount = 0 } = options;
 
     const baseExplainers = {
         'organisation': () => {
             if (hasSelectedOrganisations) {
                 if (currentModeHasData) {
-                    return "This chart shows the quantity of the selected products issued over time for the selected NHS Trusts. Each colored line represents one trust's issuing pattern for the selected products.";
+                    return "This chart shows individual NHS Trust quantities over time for your selected trusts. Each line represents one trust, allowing you to compare their usage patterns.";
                 } else {
-                    return "The selected NHS Trusts have no data for these products and quantity type. Try selecting different trusts or changing the quantity type.";
+                    return "This chart would show individual NHS Trust quantities, but the selected trusts have no data for these products.";
                 }
             } else {
-                return "This chart would show individual NHS Trust quantities over time. Select specific trusts from the search panel to see their usage patterns.";
+                return "This chart shows individual NHS Trust quantities over time. Each line represents one trust, allowing you to compare usage patterns across different trusts.";
             }
         },
 
-        'region': () => {
-            return "This chart shows total quantities aggregated by NHS region over time. Each line represents the combined usage across all trusts within that region.";
+        'icb': () => {
+            return "This chart shows quantities grouped by integrated care board (ICB) over time. Each line represents one ICB, combining data from all trusts within that area.";
         },
 
-        'icb': () => {
-            return "This chart shows total quantities aggregated by Integrated Care Board (ICB) over time. Each line represents the combined usage across all trusts within that ICB.";
+        'region': () => {
+            return "This chart shows quantities grouped by NHS region over time. Each line represents one region, combining data from all trusts within that area.";
         },
 
         'national': () => {
-            return "This chart shows the total national quantities over time, representing the combined usage across all NHS Trusts in England.";
+            return "This chart shows the total national quantities over time, combining data from all NHS Trusts in England.";
         },
 
         'product': () => {
+            const trustContext = hasSelectedOrganisations ? 
+                "across the selected NHS Trusts" : 
+                "across all NHS Trusts";
+            
             if (vmpsCount > 1) {
-                return "This chart compares quantities between different products over time. Each line represents one product, showing its total usage across all NHS Trusts.";
+                return `This chart compares quantities between different products over time. Each line represents one product, showing its total usage ${trustContext}.`;
             } else {
-                return "This chart shows quantities for the selected product over time across all NHS Trusts.";
+                return `This chart shows quantities for the selected product over time ${trustContext}.`;
             }
         },
 
         'productGroup': () => {
-            return "This chart shows quantities grouped by product category (VTM - Virtual Therapeutic Moiety) over time. Each line represents a therapeutic group, combining all related products.";
+            const trustContext = hasSelectedOrganisations ? 
+                "within the selected NHS Trusts" : 
+                "across all NHS Trusts";
+            return `This chart shows quantities grouped by product category (VTM - Virtual Therapeutic Moiety) over time ${trustContext}. Each line represents a therapeutic group, combining all related products.`;
         },
 
         'ingredient': () => {
-            return "This chart shows quantities grouped by active ingredient over time. Each line represents one ingredient, combining all products containing that ingredient.";
+            const trustContext = hasSelectedOrganisations ? 
+                "within the selected NHS Trusts" : 
+                "across all NHS Trusts";
+            return `This chart shows quantities grouped by active ingredient over time ${trustContext}. Each line represents one ingredient, combining all products containing that ingredient.`;
         },
 
         'unit': () => {
-            return "This chart shows quantities grouped by unit of measurement over time. Each line represents one unit type (e.g., tablets, bottles, ampoules).";
+            const trustContext = hasSelectedOrganisations ? 
+                "within the selected NHS Trusts" : 
+                "across all NHS Trusts";
+            return `This chart shows quantities grouped by unit of measurement over time ${trustContext}. Each line represents one unit type (e.g., tablets, bottles, ampoules).`;
         }
     };
 
@@ -1145,6 +1178,102 @@ export function getChartExplainerText(mode, options = {}) {
     }
 
     return "This chart shows the selected data over time.";
+}
+
+export function getTableExplainerText(mode, options = {}) {
+    const { 
+        hasSelectedTrusts = false, 
+        selectedTrustsCount = 0,
+        selectedPeriod = 'all',
+        latestMonth = '',
+        latestYear = '',
+        dateRange = ''
+    } = options;
+
+    function getPeriodText() {
+        switch (selectedPeriod) {
+            case 'all':
+                return dateRange ? `across the period ${dateRange}` : 'across the entire period';
+            case 'latest_month':
+                return latestMonth ? `for ${latestMonth}` : 'for the latest month';
+            case 'latest_year':
+                return latestYear ? `for ${latestYear}` : 'for the latest year';
+            case 'current_fy':
+                if (latestMonth) {
+                    const latestDate = new Date(latestMonth);
+                    const fyStartYear = latestDate.getMonth() >= 3 ? 
+                        latestDate.getFullYear() : 
+                        latestDate.getFullYear() - 1;
+                    return `for the current financial year to date (April ${fyStartYear} - ${latestMonth})`;
+                }
+                return 'for the current financial year to date';
+            default:
+                return 'across the entire period';
+        }
+    }
+
+    const periodText = getPeriodText();
+
+    const baseExplainers = {
+        'organisation': () => {
+            if (hasSelectedTrusts) {
+                return `This table shows the total quantities of the selected products issued by NHS trust ${periodText}. Data is grouped into "Selected trusts" (${selectedTrustsCount} trusts) and "All other trusts", allowing you to compare your selected NHS trusts against others.`;
+            } else {
+                return `This table shows the total quantities of the selected products issued by NHS trust ${periodText} for all trusts in England.`;
+            }
+        },
+
+        'region': () => {
+            return `This table shows the total quantities of the selected products issued in all NHS trusts in England by NHS region ${periodText}.`;
+        },
+
+        'icb': () => {
+            return `This table shows the total quantities of the selected products issued in all NHS trusts in England by integrated care board (ICB) ${periodText}.`;
+        },
+
+        'national': () => {
+            return `This table shows the total national quantity of the selected products issued in all NHS trusts in England ${periodText}.`;
+        },
+
+        'product': () => {
+            if (hasSelectedTrusts) {
+                return `This table shows the total quantities of each of the selected products issued ${periodText}, filtered to only include data from your ${selectedTrustsCount} selected NHS trusts.`;
+            } else {
+                return `This table shows the total quantities of each of the selected products issued ${periodText}, in all NHS trusts in England.`;
+            }
+        },
+
+        'productGroup': () => {
+            if (hasSelectedTrusts) {
+                return `This table shows the total quantities of the selected products issued by product group ${periodText}, filtered to only include data from your ${selectedTrustsCount} selected NHS trusts.`;
+            } else {
+                return `This table shows the total quantities of the selected products issued by product group ${periodText} for all NHS trusts in England.`;
+            }
+        },
+
+        'ingredient': () => {
+            if (hasSelectedTrusts) {
+                return `This table shows total quantities by active ingredient ${periodText}, filtered to only include data from your ${selectedTrustsCount} selected trusts.`;
+            } else {
+                return `This table shows total quantities by active ingredient ${periodText} for all trusts in England.`;
+            }
+        },
+
+        'unit': () => {
+            if (hasSelectedTrusts) {
+                return `This table shows total quantities by unit of measurement ${periodText}, filtered to only include data from your ${selectedTrustsCount} selected trusts.`;
+            } else {
+                return `This table shows total quantities by unit of measurement ${periodText} for all trusts in England.`;
+            }
+        }
+    };
+
+    const explainerFunc = baseExplainers[mode];
+    if (explainerFunc) {
+        return explainerFunc();
+    }
+
+    return `This table shows the total quantities of the selected products issued ${periodText}.`;
 }
 
 export function calculatePercentiles(data, predecessorMap = new Map(), allTrusts = []) {

--- a/viewer/content/faq/05_analyse.md
+++ b/viewer/content/faq/05_analyse.md
@@ -10,6 +10,14 @@ Quantity is the total amount of a medicine that has been issued as reported in t
 
 There is no quantity reported when a Trust has not issued a product.
 
+### How do I see ICB, regional, and national breakdowns?
+
+To view ICB, regional, and national analysis breakdowns, as well as national trust-level variation as a percentiles chart, run an analysis **without selecting any NHS Trusts** in the analysis builder. These geographic breakdown modes are only available when analysing data across all trusts.
+
+### How do I restrict an analysis to a specific set of NHS Trusts?
+
+To restrict an analysis to a specific set of NHS Trusts, select the NHS Trusts you want to include in the analysis builder. This will filter the analysis to show only data from your selected trusts.
+
 ### What is SCMD quantity?
 
 SCMD quantity is a normalised version of the raw [quantity](/faq/#what-does-quantity-mean) available in the SCMD. This quantity measure is available for all products reported in the SCMD. You can read more about how it is calculated in our blog post, [Measuring quantity in the Secondary Care Medicines Data](https://www.bennett.ox.ac.uk/blog/2025/05/measuring-quantity-in-the-secondary-care-medicines-data/). For examples of reported SCMD quantities, search for a product on the [Product Lookup page](https://hospitals.openprescribing.net/product-lookup/).


### PR DESCRIPTION
We were showing ICB, regional and national breakdowns regardless of whether any trusts were selected. This restricts ICB, region and national mode to analyses where no trusts are selected.  Additionally, if trusts are selected, the other modes available in multi-product analyses are filtered to the data for selected trusts, if any are selected.

This avoids confusion when results calculated across all trusts are shown for analyses where trusts have been selected. 

The behaviour is described in the FAQs and trust selection tooltip.