### PR TITLE
use filtered data in all modes when products filtered

### DIFF
--- a/src/components/analyse/results/AnalysisResults.svelte
+++ b/src/components/analyse/results/AnalysisResults.svelte
@@ -340,17 +340,8 @@
 
     $: if ($modeSelectorStore.selectedMode && selectedData.length > 0) {
         
-        let dataToProcess;
-        
-        if ($modeSelectorStore.selectedMode === 'organisation' || 
-            $modeSelectorStore.selectedMode === 'product' || $modeSelectorStore.selectedMode === 'productGroup' ||
-            $modeSelectorStore.selectedMode === 'unit' || $modeSelectorStore.selectedMode === 'ingredient') {
-            
-            dataToProcess = $resultsStore.filteredData && $resultsStore.filteredData.length > 0 ? 
-                $resultsStore.filteredData : selectedData;
-        } else {
-            dataToProcess = null;
-        }
+        const dataToProcess = $resultsStore.filteredData && $resultsStore.filteredData.length > 0 ? 
+            $resultsStore.filteredData : selectedData;
         
         processChartData(dataToProcess);
     }


### PR DESCRIPTION
When filtering products in the products table on the analyse page when in ICB, region or national modes, the data used for charting and the totals table was not being filtered to the selected products. 

This uses the filtered data across all modes when the products selected are filtered.