### PR TITLE
Fix missing vmps measures

### DIFF
--- a/src/components/measures/Measure.svelte
+++ b/src/components/measures/Measure.svelte
@@ -62,7 +62,7 @@
             
             const allProducts = [...parsedDenominatorVmps, ...parsedNumeratorVmps];
             const units = allProducts
-                .map(product => pluralize(product.unit))
+                .map(product => product.unit ? pluralize(product.unit) : null)
                 .filter(unit => unit && unit !== 'null' && unit !== 'undefined');
             
             return [...new Set(units)].sort();


### PR DESCRIPTION
VMPs with no quantity data were being excluded from measures. This removes the requirement for vmps to have data before they are included. These VMPs then show in the list of products included in a measure, but show no unit.