### PR TITLE
Fill in missing values with 0 in measures

### DIFF
--- a/src/components/measures/Measure.svelte
+++ b/src/components/measures/Measure.svelte
@@ -137,12 +137,10 @@
         chartData.datasets.forEach(dataset => {
             if (!dataset.hidden && dataset.data && Array.isArray(dataset.data)) {
                 dataset.data.forEach(value => {
-                    if (value !== null && value !== undefined) {
-                        if (typeof value === 'object' && value.upper !== undefined) {
-                            maxValue = Math.max(maxValue, value.upper);
-                        } else if (typeof value === 'number') {
-                            maxValue = Math.max(maxValue, value);
-                        }
+                    if (typeof value === 'object' && value.upper !== undefined) {
+                        maxValue = Math.max(maxValue, value.upper);
+                    } else if (typeof value === 'number') {
+                        maxValue = Math.max(maxValue, value);
                     }
                 });
             }
@@ -546,8 +544,8 @@
             
             if (hasdenominators === 'true') {
                 tooltipEntries.push(
-                    { label: 'Numerator', value: formatNumber(d.dataset.numerator?.[index], { addCommas: true }) },
-                    { label: 'Denominator', value: formatNumber(d.dataset.denominator?.[index], { addCommas: true }) }
+                    { label: 'Numerator', value: formatNumber(d.dataset.numerator?.[index] || 0, { addCommas: true }) },
+                    { label: 'Denominator', value: formatNumber(d.dataset.denominator?.[index] || 0, { addCommas: true }) }
                 );
             }
             
@@ -566,8 +564,8 @@
                 
                 if (hasdenominators === 'true') {
                     tooltipEntries.push(
-                        { label: 'Numerator', value: formatNumber(d.dataset.numerator?.[index], { addCommas: true }) },
-                        { label: 'Denominator', value: formatNumber(d.dataset.denominator?.[index], { addCommas: true }) }
+                        { label: 'Numerator', value: formatNumber(d.dataset.numerator?.[index] || 0, { addCommas: true }) },
+                        { label: 'Denominator', value: formatNumber(d.dataset.denominator?.[index] || 0, { addCommas: true }) }
                     );
                 }
                 

--- a/src/stores/measureChartStore.js
+++ b/src/stores/measureChartStore.js
@@ -26,16 +26,13 @@ export function getOrganisationColor(index) {
   return organisationColors[index % organisationColors.length];
 }
 
-const createDataArrayWithNulls = (data, allDates, field) => {
+const createDataArray = (data, allDates, field) => {
   if (!data || !Array.isArray(data)) {
-    return allDates.map(() => null);
+    return allDates.map(() => 0);
   }
 
   const dataMap = new Map(data.map(d => [d.month, d[field]]));
-  return allDates.map(date => {
-    const value = dataMap.get(date);
-    return value !== undefined ? value : null;
-  });
+  return allDates.map(date => dataMap.get(date) || 0);
 };
 
 export function getOrAssignColor(orgName, index = null) {
@@ -83,9 +80,9 @@ export const filteredData = derived(
             const trustData = $orgdata[trust]?.data || [];
             return {
               label: trust,
-              data: createDataArrayWithNulls(trustData, allDates, 'quantity'),
-              numerator: createDataArrayWithNulls(trustData, allDates, 'numerator'),
-              denominator: createDataArrayWithNulls(trustData, allDates, 'denominator'),
+              data: createDataArray(trustData, allDates, 'quantity'),
+              numerator: createDataArray(trustData, allDates, 'numerator'),
+              denominator: createDataArray(trustData, allDates, 'denominator'),
               color: getOrAssignColor(trust),
               spanGaps: true,
               hidden: false,
@@ -158,7 +155,7 @@ export const filteredData = derived(
         datasets = [
           {
             label: 'Median (50th percentile)',
-            data: labels.map(month => groupedPercentiles[month]?.[50] ?? null),
+            data: labels.map(month => groupedPercentiles[month]?.[50] || 0),
             color: '#DC3220',
             strokeWidth: 2,
             fill: false,
@@ -169,8 +166,8 @@ export const filteredData = derived(
           ...percentileRanges.map(({ range: [lower, upper], opacity }) => ({
             label: `${lower}th-${upper}th percentiles`,
             data: labels.map(month => ({
-              lower: groupedPercentiles[month]?.[lower] ?? null,
-              upper: groupedPercentiles[month]?.[upper] ?? null
+              lower: groupedPercentiles[month]?.[lower] || 0,
+              upper: groupedPercentiles[month]?.[upper] || 0
             })),
             color: '#005AB5',
             strokeWidth: 0,
@@ -189,9 +186,9 @@ export const filteredData = derived(
 
             return {
               label: org,
-              data: labels.map(date => orgDataPoints[date]?.quantity ?? null),
-              numerator: labels.map(date => orgDataPoints[date]?.numerator ?? null),
-              denominator: labels.map(date => orgDataPoints[date]?.denominator ?? null),
+              data: labels.map(date => orgDataPoints[date]?.quantity || 0),
+              numerator: labels.map(date => orgDataPoints[date]?.numerator || 0),
+              denominator: labels.map(date => orgDataPoints[date]?.denominator || 0),
               color: getOrAssignColor(org),
               strokeWidth: 2,
               isTrust: true,
@@ -217,15 +214,15 @@ export const filteredData = derived(
             label: 'National',
             data: labels.map(month => {
               const dataPoint = $nationaldata.data.find(d => d.month === month);
-              return dataPoint ? dataPoint.quantity : null;
+              return dataPoint ? dataPoint.quantity : 0;
             }),
             numerator: labels.map(month => {
               const dataPoint = $nationaldata.data.find(d => d.month === month);
-              return dataPoint ? dataPoint.numerator : null;
+              return dataPoint ? dataPoint.numerator : 0;
             }),
             denominator: labels.map(month => {
               const dataPoint = $nationaldata.data.find(d => d.month === month);
-              return dataPoint ? dataPoint.denominator : null;
+              return dataPoint ? dataPoint.denominator : 0;
             }),
             color: '#005AB5',
             strokeWidth: 3

--- a/viewer/content/faq/06_measures.md
+++ b/viewer/content/faq/06_measures.md
@@ -12,6 +12,16 @@ You can read more about measures in our blog, [Introducing OpenPrescribing Hospi
 
 Percentile charts show the extent of variation in medication use at the level of individual trusts. You can read more about why we use them in our blogs, [communicating variation in prescribing](https://www.bennett.ox.ac.uk/blog/2019/04/communicating-variation-in-prescribing-why-we-use-deciles/) and [highlighting variation in hospitals medicines usage](https://www.bennett.ox.ac.uk/blog/2025/04/highlighting-variation-in-hospitals-medicines-usage).
 
+### What does a value of zero mean in a measure?
+
+When viewing measures, you may see trusts with a value of zero for certain months. This can happen for two main reasons:
+
+**1. No usage:** The trust did not issue the relevant products during that month.
+
+**2. No data submission:** The trust did not submit data for the relevant products to the SCMD for that month.
+
+We cannot distinguish between true zeroes and zeroes resulting from missing data submissions. You can see the submission history for an trust on the [Submission History](https://hospitals.openprescribing.net/submission-history/) page to get an idea of the completeness of the data for a specific trust.
+
 ### Why do some trusts have out of range values?
 
 Within the SCMD, it is possible for issued quantity to be negative (see [Why are there negative values for some products?](faq/#why-are-there-negative-values-for-some-products)). When calculting measures with both a numerator and denominator, values are expected to be between 0% and 100%. However, negative values can result in the numerator being greater than the denominator (so the measure value can be greater than 100%) or the denominator being negative (so the measure value can be less than 0%).


### PR DESCRIPTION
Previously, if a trust had no data for the quantity type for the products within a measure, empty months were represented with null values which appeared as line breaks in the measures charts. For some measures with sporadic issuing, data points weren't plotted if they had no neighbouring points. 

This replaces null values with 0, so the chart lines have data points for every month. 

The reasons behind values of zero (true zeroes due to no issuing, or zeroes resulting from missing submission) is explained in the FAQs.

Resolves #31