### PR TITLE
Prevent signups to the "alerts" also signing the person up for bennett blog updates

### DIFF
--- a/templates/alerts.html
+++ b/templates/alerts.html
@@ -26,7 +26,7 @@
                                 <input type="email" name="EMAIL" class="required email w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent" id="mce-EMAIL" required="" value="" placeholder="Enter your email address">
                             </div>
                             <div class="mc-field-group input-group hidden">
-                                <input type="checkbox" name="group[7664][8]" id="mce-group[7664]-7664-1" value="" checked>
+                                <input type="checkbox" name="group[7664][8]" id="mce-group[7664]-7664-1" checked>
                             </div>
                             <div id="mce-responses" class="clear foot">
                                 <div class="response" id="mce-error-response" style="display: none;"></div>


### PR DESCRIPTION
The `value=""` for this hidden checkbox (which is telling mailchimp to sign the person up for the op-hospital alerts mailling list - `group[7664][8]`) means that although the field is marked as "checked", it isn't correctly passed to mailchimp causing the person to be signed up for this mail list AND the bennett blog update list. I think by removing this, the user will just be signed up for the correct mailing list.