### PR TITLE
aggregate across products when calculating percentiles

### DIFF
--- a/src/utils/analyseUtils.js
+++ b/src/utils/analyseUtils.js
@@ -1422,7 +1422,7 @@ export function calculatePercentiles(data, predecessorMap = new Map(), allTrusts
                         const quantity = parseFloat(entry[1]);
                         
                         if (!isNaN(quantity)) {
-                            orgMonthlyValues[orgId][month] = quantity;
+                            orgMonthlyValues[orgId][month] += quantity;
                         }
                     }
                 });


### PR DESCRIPTION
When calculating percentiles for analyses with multiple products, the quantity was being overwritten such that the monthly quantity for each trust represented the quantity for a single product rather than the aggregate of all selected products.