### PR TITLE
Extend mapping for "Refers to"

### DIFF
--- a/pipeline/atc_ddd/ddd_comments/populate_ddd_refers_to.py
+++ b/pipeline/atc_ddd/ddd_comments/populate_ddd_refers_to.py
@@ -32,6 +32,19 @@ def validate_ddd_refers_to_matches():
           WHERE comment IS NOT NULL
             AND LOWER(comment) LIKE 'refers to %'
             AND LOWER(comment) != 'refers to sc injection' -- This is a different type of DDD comment handled elsewhere
+            -- Exclude comments where the refers to inredient is not relevant to UK products
+            AND LOWER(comment) NOT IN (
+              'refers to cefoperazone',
+              'refers to cyclothiazide',
+              'refers to etidronic acid',
+              'refers to fenofibric acid',
+              'refers to mefruside',
+              'refers to methyclothiazide',
+              'refers to panipenem',
+              'refers to propyphenazone',
+              'refers to quinethazone',
+              'refers to trichlormethiazide'
+            )
         ) dc
         LEFT JOIN (
           -- Get all unique ingredients from dm+d data

--- a/pipeline/atc_ddd/ddd_comments/populate_ddd_refers_to.sql
+++ b/pipeline/atc_ddd/ddd_comments/populate_ddd_refers_to.sql
@@ -14,6 +14,19 @@ WITH ddd_comments_with_refers_to AS (
   WHERE comment IS NOT NULL 
     AND LOWER(comment) LIKE 'refers to %'
     AND LOWER(comment) != 'refers to sc injection' -- This is a different type of DDD comment handled elsewhere
+    -- Exclude comments where the refers to inredient is not relevant to UK products  
+    AND LOWER(comment) NOT IN (
+      'refers to cefoperazone',
+      'refers to cyclothiazide',
+      'refers to etidronic acid',
+      'refers to fenofibric acid',
+      'refers to mefruside',
+      'refers to methyclothiazide',
+      'refers to panipenem',
+      'refers to propyphenazone',
+      'refers to quinethazone',
+      'refers to trichlormethiazide'
+    )
 ),
 
 -- Get all unique ingredients from dm+d data (full table)


### PR DESCRIPTION
There are a number of additional comments found here:
https://github.com/bennettoxford/openprescribing-hospitals/issues/612

These changes 
- exclude comment: 'Refers to SC injection' - not relevant for this comment style
- Map comment: 'Refers to risedronic acid' to ingredient 'risedronate' - although note no risedronate combos available in UK so unused currently and may continue to flag.

I've reviewed the rest of the list. None appear to have relevant UK products available.
Main one of note - Comment: 'Refers to fenofibric acid'
This corresponds specifically to [choline fenofibrate](https://atcddd.fhi.no/atc_ddd_index/?code=C10AB11) - a specific salt of fenofibrate not currently available in the UK. It seems likely it would be really be more like an "Expressed as" type comment than refers to.
