### PR TITLE
Add diclofenac measure

### DIFF
--- a/viewer/measures/diclofenac/definition.yaml
+++ b/viewer/measures/diclofenac/definition.yaml
@@ -1,0 +1,20 @@
+name: Percentage of oral NSAIDs issued as diclofenac
+short_name: Diclofenac
+description: |
+  The percentage of all oral NSAIDs which were issued as diclofenac.
+
+why_it_matters: |
+  Oral diclofenac has been associated with a higher risk of adverse cardiovascular events compared with some other non-steroidal anti-inflammatory drugs (NSAIDs), the [MHRA]([https://www.gov.uk/drug-safety-update/diclofenac-new-contraindications-and-warnings](https://www.gov.uk/drug-safety-update/diclofenac-new-contraindications-and-warnings)) emphasise caution in its use and align its safety warnings to be similar to those for selective COX-2 inhibitors. Since safer NSAIDs are available for many indications, a high proportion of diclofenac prescriptions may reflect suboptimal prescribing and expose patients unnecessarily to increased risk. Reducing reliance on diclofenac where clinically appropriate can improve patient safety.
+
+how_is_it_calculated: >
+  We divide the number of [Defined Daily Doses (DDDs)](/faq/#what-is-a-defined-daily-dose-ddd) of oral diclofenac products by the total number of DDDs of all oral NSAID products, and then multiply by 100 to obtain a percentage each month. 
+tags:
+    - Safety
+quantity_type: ddd
+lower_is_better: true
+authored_by: Andrew Brown
+checked_by: 
+date_reviewed: 
+next_review: 
+first_published: 
+status: draft

--- a/viewer/measures/diclofenac/vmps.sql
+++ b/viewer/measures/diclofenac/vmps.sql
@@ -1,0 +1,45 @@
+SELECT DISTINCT
+    vmp.id as vmp_id,
+    CASE 
+        WHEN
+            vtm.vtm IN (
+                '36408911000001109', -- diclofenac potassium
+                '36409011000001100', -- diclofenac sodium
+                '36409111000001104' -- diclofenac + misoprostol
+            )
+            AND
+            ofr.name LIKE '%.oral'
+        THEN 'numerator'
+        ELSE 'denominator'
+    END as vmp_type
+FROM viewer_vmp vmp
+INNER JOIN viewer_vtm vtm ON vtm.id = vmp.vtm_id
+INNER JOIN viewer_vmp_ont_form_routes vofr ON vofr.vmp_id = vmp.id
+INNER JOIN viewer_ontformroute ofr ON ofr.id = vofr.ontformroute_id
+WHERE 
+    vtm.vtm IN (
+        '36408911000001109', -- diclofenac potassium
+        '36409011000001100', -- diclofenac sodium
+        '36409111000001104', -- diclofenac + misoprostol
+        '776287003', -- ibuprofen
+        '776871008', -- naproxen
+        '775123001', -- celecoxib
+        '775901004', -- etoricoxib
+        '776666003', -- meloxicam
+        '776329000', -- indometacin
+        '776450008', -- ketoprofen
+        '775513003', -- dexketoprofen
+        '776013000', -- flurbiprofen
+        '777764004', -- tiaprofenic acid
+        '774407001', -- aceclofenac
+        '775895002', -- etodolac
+        '776654009', -- mefenamic acid
+        '776850003', -- nabumetone
+        '777223005', -- piroxicam
+        '777652003', -- sulindac
+        '777707009', -- tenoxicam
+        '777800001' -- tolfenamic acid
+    )
+    AND (
+        ofr.name LIKE '%.oral'
+    )


### PR DESCRIPTION
Create measure looking at the % of all NSAIDs which are issued as diclofenac.

Aspirin is not currently included as I expect most of its usage in a secondary care context would be related to the prevention or treatment of cardiovascular disease rather than analgesia (even at 300mg strengths), so is not relevant to compare with diclofenac. Open to being told otherwise by someone who works in 2ndry care though.