### PR TITLE
New lidocaine measure and change to atropine unit

### DIFF
--- a/viewer/measures/lidocaine_2%_pfs/definition.yaml
+++ b/viewer/measures/lidocaine_2%_pfs/definition.yaml
@@ -1,6 +1,6 @@
-name: Percentage of atropine as ready-to-administer pre-filled syringes # Full name of the measure/indicator
-short_name: Percentage of atropine as pre-filled syringes # Abbreviated name or acronym
-description: Percentage of atropine as ready-to-administer pre-filled syringes. # Brief 1-2 sentence description of what this measure identifies
+name: Percentage of lidocaine 2% as ready-to-administer pre-filled syringes # Full name of the measure/indicator
+short_name: Percentage of lidocaine 2% as pre-filled syringes # Abbreviated name or acronym
+description: Percentage of lidocaine 2% as ready-to-administer pre-filled syringes. # Brief 1-2 sentence description of what this measure identifies
 why_it_matters: |
     NHS faces significant operational and productivity challenges. Licensed ready-to-administer products offer a 
     practical means of reducing cognitive load, simplifying workflows and releasing clinical capacity. They are 
@@ -10,7 +10,7 @@ why_it_matters: |
     despite clear recommendations and reported benefits for patient safety and workforce efficiency.
 how_is_it_calculated: |
     We divide the number of [ddds](/faq/#what-is-ddd-quantity) of injectable atropine issued as ampoules by the total number of 
-    ddds of injectable atropine issued. We then multiply that by 100 to obtain the % each month.    
+    ddds of injectable lidocaine 2% issued. We then multiply that by 100 to obtain the % each month.    
 tags:
     # List relevant categories (e.g. Safety, Prescribing, Monitoring)
     - Efficiency

--- a/viewer/measures/lidocaine_2%_pfs/vmps.sql
+++ b/viewer/measures/lidocaine_2%_pfs/vmps.sql
@@ -1,0 +1,11 @@
+SELECT DISTINCT
+    vmp.id as vmp_id,
+    CASE
+        WHEN vmp.code = '3601911000001107' THEN 'numerator' -- VMP code for Lidocaine 100mg/5ml (2%) solution for injection ampoules
+        ELSE 'denominator'
+    END as vmp_type
+FROM viewer_vmp vmp
+WHERE
+    vmp.code = '36039111000001101' -- VMP code for Lidocaine 100mg/5ml (2%) solution for injection pre-filled syringes
+    OR
+    vmp.code = '3601911000001107' -- VMP code for Lidocaine 100mg/5ml (2%) solution for injection ampoules


### PR DESCRIPTION
New lidocaine 2% measure 

Change for atropine measure to be measured in ddds rather than unit dose. 