### PR TITLE
Include trust type in trust summary data in analysis result data downloads

### DIFF
--- a/src/components/analyse/results/AnalysisResults.svelte
+++ b/src/components/analyse/results/AnalysisResults.svelte
@@ -736,12 +736,14 @@
                                                 const orgCodes = $organisationSearchStore.orgCodes || new Map();
                                                 const orgRegions = $organisationSearchStore.orgRegions || new Map();
                                                 const orgIcbs = $organisationSearchStore.orgIcbs || new Map();
+                                                const orgTrustTypes = $organisationSearchStore.trustTypes || new Map();
                                                 return allNames.map(name => {
                                                     return {
                                                         name,
                                                         code: orgCodes.get?.(name) ?? null,
                                                         region: orgRegions.get?.(name) ?? null,
-                                                        icb: orgIcbs.get?.(name) ?? null
+                                                        icb: orgIcbs.get?.(name) ?? null,
+                                                        trustType: orgTrustTypes.get?.(name) ?? null
                                                     };
                                                 });
                                             })(),

--- a/src/utils/csvExport.js
+++ b/src/utils/csvExport.js
@@ -130,7 +130,7 @@ export function convertToCSV(data, excludedVmps = [], selectedTrusts = null, mon
 /**
  * Convert trust totals to CSV format - lists all trusts with total issuing quantity over the period
  * @param {Array} data - The normalised analysis data
- * @param {Array} allOrganisations - List of {name, code, region, icb} for all trusts to include
+ * @param {Array} allOrganisations - List of {name, code, region, icb, trustType?} for all trusts to include
  * @param {Array} excludedVmps - List of excluded VMP codes
  * @param {Array} months - Months array
  * @returns {string} CSV formatted trust summary
@@ -160,7 +160,7 @@ export function convertTrustsSummaryToCSV(data, allOrganisations = [], excludedV
         if (item.unit) entry.units.add(item.unit);
     });
 
-    const headers = ['Trust Code', 'Trust Name', 'Region', 'ICB', 'Total Quantity', 'Unit'];
+    const headers = ['Trust Code', 'Trust Name', 'Region', 'ICB', 'Trust Type', 'Total Quantity', 'Unit'];
     const rows = [headers.join(',')];
 
     allOrganisations.forEach(org => {
@@ -168,11 +168,13 @@ export function convertTrustsSummaryToCSV(data, allOrganisations = [], excludedV
         const total = entry ? entry.total : 0;
         const unitSet = entry?.units || new Set();
         const unit = unitSet.size === 0 ? '' : unitSet.size === 1 ? [...unitSet][0] : 'multiple';
+        const trustType = org.trustType ?? org.trust_type ?? '';
         rows.push([
             org.code || '',
             `"${(org.name || '').replace(/"/g, '""')}"`,
             `"${(org.region || '').replace(/"/g, '""')}"`,
             `"${(org.icb || '').replace(/"/g, '""')}"`,
+            `"${(String(trustType)).replace(/"/g, '""')}"`,
             total,
             `"${(unit || '').replace(/"/g, '""')}"`
         ].join(','));
@@ -239,7 +241,7 @@ export function downloadCompressedCSV(csvContent, percentilesCsvContent = null, 
  * @param {Array} percentilesData - The percentiles data
  * @param {string} filename - Optional filename for the download
  * @param {Array} months - Months array
- * @param {Array} allOrganisations - Optional list of {name, code, region, icb} for trusts to include in the summary file
+ * @param {Array} allOrganisations - Optional list of {name, code, region, icb, trustType?} for trusts to include in the summary file
  */
 export function exportAnalysisDataToCSV(data, excludedVmps = [], selectedTrusts = null, percentilesData = [], filename = null, months = [], allOrganisations = null) {
     const csvContent = convertToCSV(data, excludedVmps, selectedTrusts, months);

--- a/viewer/content/faq/03_data_contents.md
+++ b/viewer/content/faq/03_data_contents.md
@@ -45,7 +45,7 @@ The platform includes data from all NHS hospital trusts in England that submit d
 
 ### How are trust types determined?
 
-The trust type for each trust submitting data to the SCMD is taken from the [Estates Returns Information Collection (ERIC)](https://digital.nhs.uk/data-and-information/publications/statistical/estates-returns-information-collection). This is a data collection containing information relating to the costs of providing and maintaining NHS estates and is mandatory for all NHS trusts. Within this, every trust is assigned a single trust type. There are 9 types of trust:
+The trust type for each trust submitting data to the SCMD is taken from the [Estates Returns Information Collection (ERIC)](https://digital.nhs.uk/data-and-information/publications/statistical/estates-returns-information-collection). This is a data collection containing information relating to the costs of providing and maintaining NHS estates and is mandatory for all NHS trusts. Within this, every trust is assigned a single trust type. We explain the categories and how they are identified in more depth in our blog post,[Understanding NHS trust types](https://www.bennett.ox.ac.uk/blog/2026/04/understanding-nhs-trust-types/). There are 9 types of trust:
 
 * Acute -Teaching
 * Acute - Small

--- a/viewer/content/faq/07_downloading_charts.md
+++ b/viewer/content/faq/07_downloading_charts.md
@@ -60,8 +60,7 @@ This file lists all NHS Trusts in scope for the analysis, with their total issui
 - **Trust Name**: The name for the NHS Trust
 - **Region**: The NHS region the trust belongs to
 - **ICB**: The Integrated Care Board (ICB) the trust belongs to
-- **Predecessors**: ODS codes of trusts that have merged into this trust (if applicable)
-- **Successors**: ODS codes of trusts this trust has merged into (if applicable)
+- **Trust Type**: The NHS trust’s [type classification](/faq/#how-are-trust-types-determined).
 - **Total Quantity**: The total quantity issued across the analysis period
 - **Unit**: The unit of measure (or "multiple" if different products use different units)
 


### PR DESCRIPTION
Adds a column indicating the trust type of each trust within the trust summary file included in the raw data download available within analysis results.