### PR TITLE
Update phenobarb measure

### DIFF
--- a/viewer/measures/phenobarbital/definition.yaml
+++ b/viewer/measures/phenobarbital/definition.yaml
@@ -8,9 +8,9 @@ why_it_matters: |
     is required. Phenobarbital Elixir BP (15 mg/5 mL) contains 38% v/v of ethanol (alcohol), and so there is potential for accumulation when ingested repeatedly, especially in 
     young children with low or immature metabolic capacity.
 how_is_it_calculated: >
-    We select all phenobarbital or phenobarbital sodium products prepared as a solution or suspension.  The quantity of each product issued as DDDs is calculated.
-    We then divide the DDDs of `Phenobarbital 15mg/5ml elixir` by the total DDDs of all selected phenobarbital products and then multiply that by 100 to 
-    obtain a percentage each month.
+    We select all phenobarbital or phenobarbital sodium products prepared as a solution or suspension. The quantity of each product issued as DDDs is calculated.
+    VMPs with ingredient strength 50 mg per 5 mL are assigned to the numerator; all other selected liquids are assigned to the denominator. We divide the sum of 
+    DDDs of the numerator by the total DDDs of all selected products and multiply by 100 to obtain a percentage each month.
 tags:
     - Safety
 quantity_type: ddd

--- a/viewer/measures/phenobarbital/vmps.sql
+++ b/viewer/measures/phenobarbital/vmps.sql
@@ -1,9 +1,16 @@
 SELECT DISTINCT
     vmp.id as vmp_id,
-    CASE 
-        WHEN vmp.code = '42133811000001100' -- Phenobarbital 15mg/5ml elixir
-        THEN 'numerator'
-        ELSE 'denominator'
+    CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM viewer_vmpingredientstrength vis
+            WHERE vis.vmp_id = vmp.id
+              AND vis.strnt_nmrtr_val = 0.01
+              AND vis.strnt_nmrtr_uom_name = 'gram'
+              AND vis.strnt_dnmtr_val = 1
+              AND vis.strnt_dnmtr_uom_name = 'ml'
+        ) THEN 'denominator'
+        ELSE 'numerator'
     END as vmp_type
 FROM viewer_vmp vmp
 INNER JOIN viewer_vtm vtm ON vtm.id = vmp.vtm_id


### PR DESCRIPTION
Updated phenobarb measure to reshare with paeds people. 
It better reflects the latest NPPG guidance which advises the use of 50mg/5ml. The numerator will capture all other strengths including the 15mg/5ml containing EtOH