### PR TITLE
Limit analysis based on vmp count not number of selected items

### DIFF
--- a/src/components/analyse/Analyse.svelte
+++ b/src/components/analyse/Analyse.svelte
@@ -24,6 +24,7 @@
   export let maxDate;
   export let orgData;
   export let isAuthenticated;
+  export let maxVmpCount = null;
 
   $: isResultsBoxPopulated = (analysisData && analysisData.length > 0) || (urlValidationErrors && urlValidationErrors.length > 0);
 
@@ -120,6 +121,7 @@
                         {maxDate}
                         {orgData}
                         isAuthenticated={isAuthenticated}
+                        maxVmpCount={maxVmpCount}
                         on:analysisStart={handleAnalysisStart}
                         on:analysisComplete={handleAnalysisComplete}
                         on:analysisError={handleAnalysisError}

--- a/src/components/analyse/analyse/AnalysisBuilder.svelte
+++ b/src/components/analyse/analyse/AnalysisBuilder.svelte
@@ -114,6 +114,13 @@
     export let orgData = null;
     export let isAuthenticated = false;
     $: isAuth = isAuthenticated === true;
+    export let maxVmpCount = null;
+
+    let resolvedVmpOverLimit = false;
+
+    function handleVmpCountChange(event) {
+        resolvedVmpOverLimit = event.detail.overLimit;
+    }
     export let mindate = null;
     export let maxdate = null;
 
@@ -653,7 +660,11 @@
               </div>
             </div>
             <div class="relative">
-              <ProductSearch on:selectionChange={handleVMPSelection}/>
+              <ProductSearch
+                on:selectionChange={handleVMPSelection}
+                on:vmpCountChange={handleVmpCountChange}
+                {maxVmpCount}
+              />
             </div>
           </div>
 
@@ -807,7 +818,7 @@
             <div class="flex gap-2 justify-between">
               <button
                 on:click={runAnalysis}
-                disabled={isAnalysisRunning || isSelectingQuantityTypes}
+                disabled={isAnalysisRunning || isSelectingQuantityTypes || resolvedVmpOverLimit}
                 class="w-64 px-6 sm:px-8 py-2 sm:py-2.5 bg-oxford-50 text-oxford-600 font-semibold rounded-md hover:bg-oxford-100 transition-colors duration-200
                      disabled:bg-gray-50 disabled:text-gray-400 disabled:cursor-not-allowed"
               >

--- a/src/components/analyse/results/AnalysisResults.svelte
+++ b/src/components/analyse/results/AnalysisResults.svelte
@@ -535,6 +535,11 @@
                                         <li>{error}</li>
                                     {/each}
                                 </ul>
+                                {#if urlValidationErrors.some(e => e.includes('unique products'))}
+                                    <p class="mt-2">
+                                        <a href="/contact/" target="_blank" class="underline font-medium hover:text-yellow-900">Contact us</a> if you need to analyse a larger selection.
+                                    </p>
+                                {/if}
                             </div>
                         </div>
                     </div>

--- a/src/components/common/ProductSearch.svelte
+++ b/src/components/common/ProductSearch.svelte
@@ -9,11 +9,16 @@
     const dispatch = createEventDispatcher();
 
     export let type = "product";
+    export let maxVmpCount = null;
 
     let searchTerm = '';
     let filteredItems = [];
     let selectedItems = [];
     let vmpCount = 0;
+
+    $: effectiveMaxVmpCount = Number(maxVmpCount) > 0 ? Number(maxVmpCount) : null;
+    $: overVmpLimit = effectiveMaxVmpCount !== null && vmpCount > effectiveMaxVmpCount;
+    $: dispatch('vmpCountChange', { overLimit: overVmpLimit });
 
     let searchTimeout;
     let isLoading = false;
@@ -77,12 +82,12 @@
         }
 
         const vmpCodes = new Set();
-        
+
         for (const item of selectedItems) {
-            const data = findItemInArray(selectedItemsData, item) || 
-                        lastSearchResults.find(i => i.code === item.code) || 
+            const data = findItemInArray(selectedItemsData, item) ||
+                        lastSearchResults.find(i => i.code === item.code) ||
                         filteredItems.find(i => i.code === item.code);
-            
+
             if (data) {
                 if (item.type === 'vmp') {
                     vmpCodes.add(item.code);
@@ -93,7 +98,7 @@
                 }
             }
         }
-        
+
         vmpCount = vmpCodes.size;
     }
 
@@ -129,7 +134,7 @@
                 selectedItemsData = selectedItemsData.filter(data => !(data.code === item.code && data.type === item.type));
             }
         } else {
-            const parentVtm = filteredItems.find(vtm => 
+            const parentVtm = filteredItems.find(vtm =>
                 vtm.type === 'vtm' && vtm.vmps?.some(vmp => vmp.code === item.code)
             );
             const parentVtmSelected = parentVtm && isItemSelected(parentVtm, selectedItems);
@@ -143,7 +148,7 @@
                 }
             }
         }
-        
+
         
         dispatch('selectionChange', { items: selectedItems });
         calculateVmpCount();
@@ -642,12 +647,11 @@
                     <p class="mt-3 text-sm text-gray-600">
                         {#if vmpCount > 0}
                             This selection will analyse {vmpCount} unique product{vmpCount !== 1 ? 's' : ''}.
-                            {#if vmpCount > 100}
-                                <span class="block mt-1 text-amber-600 font-medium">
-                                    Warning: This is a large number of products. The analysis may take a long time. 
-                                    Consider making your selection more specific.
-                                </span>
-                            {/if}
+                        {/if}
+                        {#if overVmpLimit}
+                            <span class="block mt-1 text-red-600 font-medium">
+                                This is over the limit of {effectiveMaxVmpCount} unique products. Please narrow your selection before running the analysis, or <a href="/contact/" target="_blank" class="underline hover:text-red-800">contact us</a> if you need to analyse a larger selection.
+                            </span>
                         {/if}
                     </p>
             </div>

--- a/templates/analyse.html
+++ b/templates/analyse.html
@@ -14,6 +14,7 @@
         minDate="{{ date_range.min_date }}"
         maxDate="{{ date_range.max_date }}"
         orgData="{{ org_data }}"
+        maxVmpCount="{{ max_vmp_count }}"
         {% if user.is_authenticated %}isAuthenticated="true"{% endif %}
     ></layout-component>
 </div>

--- a/viewer/tests/test_api.py
+++ b/viewer/tests/test_api.py
@@ -12,7 +12,9 @@ from viewer.models import (
     VTM,
     DDDQuantity,
     DataStatus,
+    Ingredient,
 )
+from viewer.views.api import MAX_ANALYSIS_VMP_COUNT
 
 
 @pytest.fixture
@@ -193,3 +195,74 @@ class TestGetQuantityData:
         ]
         assert len(org_items) == 1
         assert org_items[0]["data"] == [1.0, 2.0, 3.0]
+
+
+@pytest.mark.django_db
+class TestValidateAnalysisParamsVmpCap:
+
+    def _call(self, **params):
+        client = Client()
+        query = "&".join(
+            f"{key}={value}" for key, value in params.items()
+        )
+        url = reverse("viewer:validate_analysis_params")
+        return client.get(f"{url}?{query}" if query else url)
+
+    def _create_vmps(self, n, vtm=None, code_prefix="1000"):
+        vmps = []
+        for i in range(n):
+            vmps.append(
+                VMP.objects.create(
+                    code=f"{code_prefix}{i:04d}",
+                    name=f"VMP {i}",
+                    vtm=vtm,
+                )
+            )
+        return vmps
+
+    def test_accepts_selection_exactly_at_cap(self):
+        vtm = VTM.objects.create(vtm="100", name="Cap VTM")
+        self._create_vmps(MAX_ANALYSIS_VMP_COUNT, vtm=vtm, code_prefix="2000")
+
+        response = self._call(vtms=vtm.vtm)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["errors"] == []
+        assert data["vmp_count"] == MAX_ANALYSIS_VMP_COUNT
+        assert len(data["valid_products"]) == 1
+
+    def test_rejects_selection_one_over_cap(self):
+        vtm = VTM.objects.create(vtm="101", name="Over-cap VTM")
+        self._create_vmps(MAX_ANALYSIS_VMP_COUNT + 1, vtm=vtm, code_prefix="3000")
+
+        response = self._call(vtms=vtm.vtm)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["vmp_count"] == MAX_ANALYSIS_VMP_COUNT + 1
+        assert any(
+            "maximum of" in err.lower() and "unique products" in err.lower()
+            for err in data["errors"]
+        ), f"Expected cap error in {data['errors']!r}"
+
+    def test_counts_union_not_sum_across_overlapping_selections(self):
+        """Two ingredients with overlapping VMPs count as a union, not a sum."""
+        ingredient_a = Ingredient.objects.create(code="900000001", name="Ingredient A")
+        ingredient_b = Ingredient.objects.create(code="900000002", name="Ingredient B")
+
+        overlap = self._create_vmps(3, code_prefix="4000")
+        only_a = self._create_vmps(1, code_prefix="4001")
+        only_b = self._create_vmps(1, code_prefix="4002")
+
+        for vmp in overlap + only_a:
+            vmp.ingredients.add(ingredient_a)
+        for vmp in overlap + only_b:
+            vmp.ingredients.add(ingredient_b)
+
+        response = self._call(ingredients=f"{ingredient_a.code},{ingredient_b.code}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["errors"] == []
+        assert data["vmp_count"] == 5

--- a/viewer/views/analyse.py
+++ b/viewer/views/analyse.py
@@ -3,6 +3,7 @@ import json
 
 from ..mixins import MaintenanceModeMixin
 from ..utils import get_organisation_data
+from .api import MAX_ANALYSIS_VMP_COUNT
 
 
 class AnalyseView(MaintenanceModeMixin, TemplateView):
@@ -23,5 +24,7 @@ class AnalyseView(MaintenanceModeMixin, TemplateView):
             'regions_hierarchy': org_data.get('regions_hierarchy', []),
             'cancer_alliances': org_data.get('cancer_alliances', []),
         }, default=str)
+
+        context['max_vmp_count'] = MAX_ANALYSIS_VMP_COUNT
 
         return context

--- a/viewer/views/api.py
+++ b/viewer/views/api.py
@@ -38,6 +38,7 @@ MAX_INGREDIENT_CANDIDATES = 200
 MAX_INGREDIENT_RESULTS = 50
 MAX_ATC_CANDIDATES = 200
 MAX_ATC_RESULTS = 50
+MAX_ANALYSIS_VMP_COUNT = 250
 
 
 def _product_searchable_tokens(vmp):
@@ -1291,13 +1292,12 @@ def validate_analysis_params(request):
             unique_products.append(product)
     valid_products = unique_products
 
-    # this is number of items selected, which may represent more than 20 products
-    MAX_PRODUCT_SELECTION_LIMIT = 20
-    original_count = len(valid_products)
-
-    if original_count > MAX_PRODUCT_SELECTION_LIMIT:
-        valid_products = valid_products[:MAX_PRODUCT_SELECTION_LIMIT]
-        errors.append(f"Maximum of {MAX_PRODUCT_SELECTION_LIMIT} items allowed")
+    if len(vmp_ids) > MAX_ANALYSIS_VMP_COUNT:
+        errors.append(
+            f"Selection includes {len(vmp_ids)} unique products; "
+            f"maximum of {MAX_ANALYSIS_VMP_COUNT} allowed. "
+            f"Please narrow the selection."
+        )
 
     return Response({
         'valid_products': valid_products,


### PR DESCRIPTION
Sets a cap of 250 VMPs for custom analyses, which is enforced in the builder and when hydrating from a URL

Resolves #785 