### PR TITLE
add selected trust/region to the title on measure list page

### DIFF
--- a/src/components/measures/MeasuresList.svelte
+++ b/src/components/measures/MeasuresList.svelte
@@ -106,6 +106,7 @@
     tagsData={tagsData}
     selectedTags={initialTags}
     archivedCount={parsedArchivedMeasures.length}
+    previewMode={previewMode}
   />
 </div>
 

--- a/src/components/measures/MeasuresListControls.svelte
+++ b/src/components/measures/MeasuresListControls.svelte
@@ -9,7 +9,8 @@
         selectedSort: { type: 'String', reflect: true },
         tagsData: { type: 'String', reflect: true },
         selectedTags: { type: 'String', reflect: true },
-        archivedCount: { type: 'Number', reflect: true }
+        archivedCount: { type: 'Number', reflect: true },
+        previewMode: { type: 'String', reflect: true }
     },
     shadow: 'none'
 }} />
@@ -38,6 +39,7 @@
     export let tagsData = '[]';
     export let selectedTags = '';
     export let archivedCount = 0;
+    export let previewMode = 'false';
 
     let parsedOrgData = {};
     let parsedRegionData = [];
@@ -59,10 +61,25 @@
         { value: 'newest', label: 'Newest first' },
     ];
     $: selectedItems = $organisationSearchStore?.selectedItems || [];
-    $: singleTrustCode = $mode === 'trust' && selectedItems.length === 1
-        ? findPrimaryTrustCode(selectedItems)
-        : null;
-    $: effectiveTrustCode = $selectedCodeStore || singleTrustCode || '';
+
+    $: listPageTitle = (() => {
+        const isPreview = previewMode === 'true';
+        const base = isPreview ? 'Measure Previews' : 'Measures';
+        let label = '';
+        if ($mode === 'trust' && $selectedCodeStore) {
+            label = (parsedOrgData?.orgs || {})[$selectedCodeStore] || selectedItems[0] || '';
+        } else if ($mode === 'region' && $selectedCodeStore) {
+            label = parsedRegionData.find((r) => r.code === $selectedCodeStore)?.name
+                || selectedItems[0] || '';
+        }
+        return label ? `${base} - ${label}` : base;
+    })();
+
+    $: if (!isInitialLoad && typeof document !== 'undefined') {
+        document.title = listPageTitle;
+        const h1 = document.getElementById('measures-list-heading');
+        if (h1) h1.textContent = listPageTitle;
+    }
 
     function findPrimaryTrustCode(items) {
         const primaryName = items[0];

--- a/templates/measures_list.html
+++ b/templates/measures_list.html
@@ -6,7 +6,7 @@
     {% vite_asset 'src/components/measures/MeasuresList.svelte' %}
 {% endblock %}
 
-{% block title %}{% if preview_mode %}Measure Previews{% else %}Measures{% endif %}{% endblock %}
+{% block title %}{% if preview_mode %}Measure Previews{% else %}Measures{% endif %}{% if list_selection_label %} - {{ list_selection_label }}{% endif %}{% endblock %}
 {% block content %}
 
 <div class="container xl:max-w-screen-xl pt-2 md:pt-6 pb-4">
@@ -14,8 +14,8 @@
         <!-- Header Section -->
         <div class="mb-4">
             <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
-                <h1 class="text-4xl font-bold text-gray-900 tracking-tight">
-                    {% if preview_mode %}Measure Previews{% else %}Measures{% endif %}
+                <h1 id="measures-list-heading" class="text-4xl font-bold text-gray-900 tracking-tight">
+                    {% if preview_mode %}Measure Previews{% else %}Measures{% endif %}{% if list_selection_label %} - {{ list_selection_label }}{% endif %}
                 </h1>
                 {% if user.is_authenticated %}
                     {% if preview_mode %}

--- a/viewer/views/measures.py
+++ b/viewer/views/measures.py
@@ -438,6 +438,14 @@ class MeasuresListView(MaintenanceModeMixin, TemplateView):
         }.get(selected_mode, '')
         org_data = get_organisation_data()
         region_list = get_region_list()
+        list_selection_label = ''
+        if selected_mode == 'trust' and selected_code:
+            list_selection_label = (org_data.get('orgs') or {}).get(selected_code) or ''
+        elif selected_mode == 'region' and selected_code:
+            list_selection_label = next(
+                (r['name'] for r in region_list if r.get('code') == selected_code),
+                '',
+            ) or selected_code
         context.update({
             "tags_json": json.dumps(
                 [{"id": t.id, "name": t.name, "slug": slugify(t.name), "colour": t.colour or "#6b7280"}
@@ -452,6 +460,7 @@ class MeasuresListView(MaintenanceModeMixin, TemplateView):
             "selected_trust_codes_param": selected_trust_code if selected_mode == 'trust' else "",
             "org_data_json": json.dumps(org_data, cls=DjangoJSONEncoder),
             "region_data_json": json.dumps(region_list, cls=DjangoJSONEncoder),
+            "list_selection_label": list_selection_label,
         })
 
         measures_for_charts = list(measures) + list(archived_measures)


### PR DESCRIPTION
To make the selected trust/region clear if coming to a page from a shared link. Builds on #702
