### PR TITLE
Update out of date uom codes

### DIFF
--- a/pipeline/dmd/import_dmd_uom.sql
+++ b/pipeline/dmd/import_dmd_uom.sql
@@ -1,28 +1,14 @@
-MERGE INTO `{{ PROJECT_ID }}.{{ DATASET_ID }}.{{ DMD_UOM_TABLE_ID }}` T
-USING (
-  SELECT 
-    CAST(cd AS STRING) as uom_code,
-    CAST(cdprev AS STRING) as uom_code_prev,
-    CAST(cddt AS DATE) as change_date,
-    descr as description
+CREATE OR REPLACE TABLE `{{ PROJECT_ID }}.{{ DATASET_ID }}.{{ DMD_UOM_TABLE_ID }}`
+CLUSTER BY uom_code
+AS
+SELECT
+  CAST(cd AS STRING) AS uom_code,
+  CAST(cdprev AS STRING) AS uom_code_prev,
+  CAST(cddt AS DATE) AS change_date,
+  descr AS description
+FROM dmd.unitofmeasure
+WHERE CAST(cd AS STRING) NOT IN (
+  SELECT CAST(cdprev AS STRING)
   FROM dmd.unitofmeasure
-) S
-ON T.uom_code = S.uom_code
-WHEN MATCHED THEN
-  UPDATE SET
-    uom_code_prev = S.uom_code_prev,
-    change_date = S.change_date,
-    description = S.description
-WHEN NOT MATCHED THEN
-  INSERT (
-    uom_code,
-    uom_code_prev,
-    change_date,
-    description
-  )
-  VALUES (
-    S.uom_code,
-    S.uom_code_prev,
-    S.change_date,
-    S.description
-  );
+  WHERE cdprev IS NOT NULL
+);

--- a/pipeline/mappings/import_unit_conversion.py
+++ b/pipeline/mappings/import_unit_conversion.py
@@ -151,7 +151,7 @@ def create_units_dict() -> Dict:
             "basis": "vector genome",
             "conversion_factor": 1000000000,
             "id": "10697811000001107",
-            "basis_id": "10696211000001109",
+            "basis_id": "1388150000",
         },
         "glove": {
             "basis": "glove",
@@ -490,8 +490,8 @@ def create_units_dict() -> Dict:
         "tera vector genome": {
             "basis": "vector genome",
             "conversion_factor": 1000000000000,
-            "id": "10696711000001102",
-            "basis_id": "10696211000001109",
+            "id": "1495251000168101",
+            "basis_id": "1388150000",
         },
         "truss": {
             "basis": "truss",


### PR DESCRIPTION
Some of the UOM id's included in the unit conversion table have been updated. This updates them in the mapping table. It also updates the UOM import so that it rebuilds on each import and excludes rows in the raw data for superseded codes.