### PR TITLE
Add 'pre-filled disposable injection' to SQL list

### DIFF
--- a/viewer/measures/potassium_rta/vmps.sql
+++ b/viewer/measures/potassium_rta/vmps.sql
@@ -42,6 +42,6 @@ AND LOWER(TRIM(vmp.unit_dose_uom)) IN (
     'bottle',
     'ampoule',
     'pre-filled syringe',
-    'pre-filled disposable injection'
+    'pre-filled disposable injection',
     'prefilled syringe'
 );

--- a/viewer/measures/potassium_rta/vmps.sql
+++ b/viewer/measures/potassium_rta/vmps.sql
@@ -42,5 +42,6 @@ AND LOWER(TRIM(vmp.unit_dose_uom)) IN (
     'bottle',
     'ampoule',
     'pre-filled syringe',
+    'pre-filled disposable injection'
     'prefilled syringe'
 );


### PR DESCRIPTION
Manchester were surprised at their % in the measure, and talked about using lots of pre-filled syringes. 

These are not listed in the measure, it looks as though we were missing this unit of measure.
It also might be because they don't have a VTM