### PR TITLE
Remove unused date-fns leftover from Chart.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/typography": "^0.5.20",
         "clipboard": "^2.0.11",
-        "date-fns": "^3.6.0",
         "highcharts": "^13.0.0",
         "jszip": "^3.10.1",
         "pluralize": "^8.0.0",
@@ -2391,15 +2390,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/deepmerge": {
@@ -5675,11 +5665,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
-    },
-    "date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
     },
     "deepmerge": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/typography": "^0.5.20",
     "clipboard": "^2.0.11",
-    "date-fns": "^3.6.0",
     "highcharts": "^13.0.0",
     "jszip": "^3.10.1",
     "pluralize": "^8.0.0",


### PR DESCRIPTION
Removes the unused `date-fns` dependency left behind after Chart.js was replaced with Highcharts