### PR TITLE
Modify SQL query to filter for heparin sodium

### DIFF
--- a/viewer/measures/heparin_per_1000_admissions/vmps.sql
+++ b/viewer/measures/heparin_per_1000_admissions/vmps.sql
@@ -9,10 +9,6 @@ WHERE EXISTS (
         ON ing.id = vis.ingredient_id
     WHERE vis.vmp_id = vmp.id
       AND LOWER(ing.name) LIKE '%heparin sodium%'
-      AND (
-            (vis.strnt_nmrtr_val = 1000  AND vis.strnt_dnmtr_val = 1)
-         OR (vis.strnt_nmrtr_val = 5000  AND vis.strnt_dnmtr_val = 1)
-         OR (vis.strnt_nmrtr_val = 25000 AND vis.strnt_dnmtr_val = 5)
-      )
+      AND vis.strnt_nmrtr_val >= 20000
 )
 AND LOWER(TRIM(vmp.unit_dose_uom)) NOT LIKE '%eye%';


### PR DESCRIPTION
products containing 20,000 units or above as a marker of most likely use being UFH infusion