### PR TITLE
Add analysis scope to Analyse

### DIFF
--- a/src/components/analyse/Analyse.svelte
+++ b/src/components/analyse/Analyse.svelte
@@ -18,7 +18,10 @@
   export let minDate;
   export let maxDate;
   export let orgData;
+  export let isAuthenticated = false;
   export let maxVmpCount = null;
+
+  $: isAuth = isAuthenticated === true || isAuthenticated === 'true';
 
   $: isResultsBoxPopulated = $resultsStore.showResults
     || (urlValidationErrors && urlValidationErrors.length > 0);
@@ -81,12 +84,14 @@
                         {minDate}
                         {maxDate}
                         {orgData}
+                        isAuthenticated={isAuth}
                         maxVmpCount={maxVmpCount}
                         on:analysisStart={handleAnalysisStart}
                         on:analysisComplete={handleAnalysisComplete}
                         on:analysisError={handleAnalysisError}
                         on:analysisClear={handleAnalysisClear}
                         on:urlValidationErrors={handleUrlValidationErrors}
+                        on:overlaySelectionChange={() => analysisResults?.syncOverlayFromBuilder?.()}
                     ></analysis-builder>
                 </div>
                 {#if !isLargeScreen}
@@ -122,6 +127,7 @@
                 <AnalysisResults
                     bind:this={analysisResults}
                     className="flex-grow"
+                    isAuthenticated={isAuth}
                     {urlValidationErrors}
                 />
             </div>

--- a/src/components/analyse/Analyse.svelte
+++ b/src/components/analyse/Analyse.svelte
@@ -1,4 +1,4 @@
-<svelte:options customElement={{
+<svelte:options runes={false} customElement={{
     tag: 'layout-component',
     shadow: 'none'
   }} />
@@ -7,14 +7,9 @@
   import { onMount } from 'svelte';
   import AnalysisBuilder from './analyse/AnalysisBuilder.svelte';
   import AnalysisResults from './results/AnalysisResults.svelte';
-  import { writable } from 'svelte/store';
-  import { analyseOptions } from '../../stores/analyseOptionsStore';
-  import { organisationSearchStore } from '../../stores/organisationSearchStore';
+  import { resultsStore, setAnalysisRunning, clearAnalysisResults } from '../../stores/resultsStore';
 
-  let isAnalysisRunning = writable(false);
-  let isOrganisationDropdownOpen = false;
-  let showResults = false;
-  let analysisData = null;
+  let analysisResults;
   let isAnalyseBoxCollapsed = false;
   let isLargeScreen = false;
   let isResultsBoxPopulated = false;
@@ -23,53 +18,37 @@
   export let minDate;
   export let maxDate;
   export let orgData;
-  export let isAuthenticated;
   export let maxVmpCount = null;
 
-  $: isResultsBoxPopulated = (analysisData && analysisData.length > 0) || (urlValidationErrors && urlValidationErrors.length > 0);
+  $: isResultsBoxPopulated = $resultsStore.showResults
+    || (urlValidationErrors && urlValidationErrors.length > 0);
 
   function handleAnalysisStart() {
-    showResults = true;
-    isAnalysisRunning.set(true);
-    analysisData = null;
+    setAnalysisRunning(true);
+    analysisResults?.prepareForNewRun?.();
     isAnalyseBoxCollapsed = true;
   }
 
   function handleAnalysisComplete(event) {
-    isAnalysisRunning.set(false);
-    analysisData = event.detail;
+    analysisResults?.loadAnalysis?.(event.detail);
     isAnalyseBoxCollapsed = true;
   }
 
   function handleAnalysisError() {
-    isAnalysisRunning.set(false);
-  }
-
-  function handleOrganisationDropdownToggle(event) {
-    isOrganisationDropdownOpen = event.detail.isOpen;
+    setAnalysisRunning(false);
   }
 
   function handleUrlValidationErrors(event) {
     urlValidationErrors = event.detail.errors || [];
-  }
-
-  $: if (urlValidationErrors && urlValidationErrors.length > 0 && !showResults) {
-    showResults = true;
+    if (urlValidationErrors.length > 0) {
+      resultsStore.update(store => ({ ...store, showResults: true }));
+    }
   }
 
   function handleAnalysisClear() {
-    showResults = false;
-    analysisData = null;
-    isAnalysisRunning.set(false);
+    clearAnalysisResults();
+    analysisResults?.prepareForNewRun?.();
     urlValidationErrors = [];
-  }
-
-  function handleVMPSelection(event) {
-    analyseOptions.update(options => ({
-        ...options,
-        selectedProducts: event.detail.items,
-        searchType: event.detail.type
-    }));
   }
 
   function toggleAnalyseBox() {
@@ -83,52 +62,30 @@
   window.addEventListener('resize', checkScreenSize);
   onMount(() => {
     checkScreenSize();
-    if (orgData) {
-        try {
-            const parsedData = typeof orgData === 'string' ? JSON.parse(orgData) : orgData;
-
-            organisationSearchStore.setOrganisationData({
-                orgs: parsedData.orgs || {},
-                org_codes: parsedData.org_codes || {},
-                trust_types: parsedData.trust_types || {},
-                org_regions: parsedData.org_regions || {},
-                org_icbs: parsedData.org_icbs || {},
-                org_cancer_alliances: parsedData.org_cancer_alliances || {},
-                org_shelford_group: parsedData.org_shelford_group || {},
-                regions_hierarchy: parsedData.regions_hierarchy || [],
-                cancer_alliances: parsedData.cancer_alliances || []
-            });
-            organisationSearchStore.setFilterType('trust');
-        } catch (error) {
-            console.error('Error parsing ODS data:', error);
-        }
-    }
   });
 </script>
 
 
   <div class="max-w-screen-2xl mx-auto min-h-screen p-4 sm:p-6">
     <div class="grid grid-cols-1 lg:grid-cols-[350px_1fr] lg:gap-6">
-        <div class="mb-4 lg:mb-0 transition-all duration-300 ease-in-out">
+        <div class="mb-4 lg:mb-0 min-w-0 max-w-full transition-all duration-300 ease-in-out">
             <div class="bg-white rounded-lg shadow-md flex flex-col overflow-visible relative">
                 <div class="bg-gradient-to-r from-oxford-600/60 via-bn-roman-600/70 to-bn-strawberry-600/60 text-white p-2 rounded-t-lg">
                     <h2 class="text-lg font-semibold">Analysis builder</h2>
                 </div>
-                <div class="flex-grow overflow-y-auto overflow-x-visible transition-all duration-300 ease-in-out"
+                <div class="flex-grow overflow-y-auto overflow-x-hidden transition-all duration-300 ease-in-out"
                      class:max-h-0={isAnalyseBoxCollapsed && !isLargeScreen}
-                     class:max-h-[1000px]={!isAnalyseBoxCollapsed || isLargeScreen}>
+                     class:max-h-[1000px]={!isAnalyseBoxCollapsed && !isLargeScreen}>
                     <analysis-builder
+                        class="block w-full max-w-full"
                         {minDate}
                         {maxDate}
                         {orgData}
-                        isAuthenticated={isAuthenticated}
                         maxVmpCount={maxVmpCount}
                         on:analysisStart={handleAnalysisStart}
                         on:analysisComplete={handleAnalysisComplete}
                         on:analysisError={handleAnalysisError}
                         on:analysisClear={handleAnalysisClear}
-                        on:organisationDropdownToggle={handleOrganisationDropdownToggle}
-                        on:vmpSelection={handleVMPSelection}
                         on:urlValidationErrors={handleUrlValidationErrors}
                     ></analysis-builder>
                 </div>
@@ -162,13 +119,11 @@
                 <div class="bg-gradient-to-r from-oxford-600/60 via-bn-roman-600/70 to-bn-strawberry-600/60 text-white p-2 rounded-t-lg">
                     <h2 class="text-lg font-semibold">Results</h2>
                 </div>
-                <analysis-results
-                    class="flex-grow"
-                    isAnalysisRunning={$isAnalysisRunning}
-                    analysisData={analysisData}
-                    {showResults}
+                <AnalysisResults
+                    bind:this={analysisResults}
+                    className="flex-grow"
                     {urlValidationErrors}
-                ></analysis-results>
+                />
             </div>
         </div>
     </div>

--- a/src/components/analyse/analyse/AnalysisBuilder.svelte
+++ b/src/components/analyse/analyse/AnalysisBuilder.svelte
@@ -1,4 +1,4 @@
-<svelte:options customElement={{
+<svelte:options runes={false} customElement={{
     tag: 'analysis-builder',
     shadow: 'none'
   }} />
@@ -8,21 +8,47 @@
     import '../../../styles/styles.css';
     import ProductSearch from '../../common/ProductSearch.svelte';
     import OrganisationSearch from '../../common/OrganisationSearch.svelte';
-    import OrganisationSearchFiltered from '../../common/OrganisationSearchFiltered.svelte';
+    import AnalysisScopePanel from './AnalysisScopePanel.svelte';
     import { createEventDispatcher } from 'svelte';
     import { organisationSearchStore } from '../../../stores/organisationSearchStore';
     import { analyseOptions } from '../../../stores/analyseOptionsStore';
     import { resultsStore, updateResults } from '../../../stores/resultsStore';
     import { modeSelectorStore } from '../../../stores/modeSelectorStore';
-    import { normaliseMode } from '../../../utils/analyseUtils.js';
-    import { buildAnalysisRequestPayload } from '../../../utils/analyseUtils.js';
+    import {
+        ANALYSIS_SCOPE,
+        normaliseMode,
+        isAggregationChartMode,
+    } from '../lib/analysisScope.js';
+    import {
+        createEmptyScopeFilters,
+        decodeTrustTypeFromUrl,
+        hasAnyScopeFilters,
+        normaliseScopeFilters,
+    } from '../../../utils/scopeFilters.js';
+    import {
+        ANALYSIS_QUANTITY_PARAM,
+        SUPPORTED_ANALYSIS_PARAMS,
+        getShowPercentilesParam,
+        getCancerAllianceCodeMaps,
+        getRegionCodeMaps,
+        updateAnalysisUrl as writeAnalysisUrlParams,
+        planAnalysisHydrate,
+        planValidationStorePatch,
+        finishValidatedHydrate,
+    } from '../lib/analyseUrlParams.js';
+    import {
+        validateAnalysisRun,
+        buildAnalysisRunPlan,
+        executeAnalysisFetch,
+        completeAnalysisRun,
+    } from '../lib/runAnalysis.js';
     import {
         getCookie,
         getUrlParams,
-        formatArrayParam,
         setUrlParams,
         cleanupUrl,
     } from '../../../utils/utils';
+    import { allOverlaySelection } from '../lib/chartOverlay.js';
     
     const dispatch = createEventDispatcher();
 
@@ -33,37 +59,6 @@
         'Defined Daily Dose Quantity'
     ];
 
-    const PRODUCT_PARAM_BY_TYPE = {
-        vmp: 'vmps',
-        vtm: 'vtms',
-        ingredient: 'ingredients',
-        atc: 'atcs'
-    };
-
-    const PRODUCT_TYPE_ORDER = Object.keys(PRODUCT_PARAM_BY_TYPE);
-
-    const ANALYSIS_TRUSTS_PARAM = 'trusts';
-    const ANALYSIS_QUANTITY_PARAM = 'quantity';
-    const ANALYSIS_MODE_PARAM = 'mode';
-    const ANALYSIS_PERCENTILES_PARAM = 'show_percentiles';
-    const ANALYSIS_EXCLUDED_VMPS_PARAM = 'excluded_vmps';
-
-    const SUPPORTED_ANALYSIS_PARAMS = [
-        ...Object.values(PRODUCT_PARAM_BY_TYPE),
-        ANALYSIS_TRUSTS_PARAM,
-        ANALYSIS_QUANTITY_PARAM,
-        ANALYSIS_MODE_PARAM,
-        ANALYSIS_PERCENTILES_PARAM,
-        ANALYSIS_EXCLUDED_VMPS_PARAM
-    ];
-
-    const QUANTITY_TYPE_CODES = {
-        'SCMD Quantity': 'scmd',
-        'Unit Dose Quantity': 'dose',
-        'Ingredient Quantity': 'ingredient',
-        'Defined Daily Dose Quantity': 'ddd'
-    };
-
     let isAnalysisRunning = false;
     let errorMessage = '';
     let isSelectingQuantityTypes = false;
@@ -71,6 +66,8 @@
     let recommendedQuantityTypes = [];
     let selectedQuantityType = null;
     let isQuantityDropdownOpen = false;
+    let selectedScope = ANALYSIS_SCOPE.ALL;
+    let selectedScopeFilters = createEmptyScopeFilters();
 
     let urlState = {
         mode: null,
@@ -85,8 +82,15 @@
     $: searchType = $analyseOptions.searchType;
     $: selectedQuantityType = $analyseOptions.quantityType;
     $: selectedTrusts = $organisationSearchStore.selectedItems || [];
+    $: resultsOverlayTrusts = $analyseOptions.selectedOrganisations || [];
     $: selectedMode = $modeSelectorStore.selectedMode;
     $: showPercentiles = $resultsStore.showPercentiles;
+    $: effectiveMode = normaliseMode(selectedMode) || urlState.mode;
+    $: trustsForUrl = selectedScope === ANALYSIS_SCOPE.TRUST
+        ? selectedTrusts
+        : (isAggregationChartMode(effectiveMode)
+            ? []
+            : (isAuth ? resultsOverlayTrusts : selectedTrusts));
 
     $: urlState.excludedVmps = Array.isArray($resultsStore.excludedVmps)
         ? Array.from(new Set($resultsStore.excludedVmps.filter(Boolean).map(String))).sort()
@@ -96,122 +100,60 @@
         urlState.mode = null;
     }
 
-    $: effectiveMode = normaliseMode(selectedMode) || urlState.mode;
+    $: chartRegionsForUrl = effectiveMode === 'region'
+        ? $analyseOptions.selectedChartRegions
+        : null;
+    $: chartIcbsForUrl = effectiveMode === 'icb'
+        ? $analyseOptions.selectedChartIcbs
+        : null;
 
     $: if (!urlState.suppressSync && urlState.validationErrors.length === 0) {
-        const currentMode = effectiveMode || 'trust';
-        const currentShowPercentiles = getShowPercentilesParam(currentMode, selectedTrusts, showPercentiles);
-        updateAnalysisUrl(
-            selectedVMPs,
-            selectedTrusts,
-            selectedQuantityType,
-            effectiveMode,
-            currentShowPercentiles,
-            urlState.excludedVmps
+        const { regionCodeByName, icbCodeByName } = getRegionCodeMaps(
+            $organisationSearchStore.regionsHierarchy || []
         );
+        const { codeByName: cancerAllianceCodeByName } = getCancerAllianceCodeMaps(
+            typeof organisationSearchStore.getCancerAlliances === 'function'
+                ? organisationSearchStore.getCancerAlliances()
+                : []
+        );
+        const currentShowPercentiles = getShowPercentilesParam(
+            effectiveMode,
+            trustsForUrl,
+            showPercentiles,
+            selectedScope
+        );
+        writeAnalysisUrlParams({
+            products: selectedVMPs,
+            trusts: trustsForUrl,
+            quantityType: selectedQuantityType,
+            scope: selectedScope,
+            scopeFilters: selectedScopeFilters,
+            mode: effectiveMode,
+            showPercentiles: currentShowPercentiles,
+            excludedVmps: urlState.excludedVmps,
+            chartRegions: chartRegionsForUrl,
+            chartIcbs: chartIcbsForUrl,
+            getOrgCode: (name) => organisationSearchStore.getOrgCode(name),
+            regionCodeByName,
+            icbCodeByName,
+            cancerAllianceCodeByName,
+        });
     }
 
     export let orgData = null;
     export let isAuthenticated = false;
-    $: isAuth = isAuthenticated === true;
     export let maxVmpCount = null;
+
+    $: isAuth = isAuthenticated === true || isAuthenticated === 'true';
+    $: if (!isAuth && selectedScope !== ANALYSIS_SCOPE.ALL) {
+        selectedScope = ANALYSIS_SCOPE.ALL;
+        selectedScopeFilters = createEmptyScopeFilters();
+    }
 
     let resolvedVmpOverLimit = false;
 
     function handleVmpCountChange(event) {
         resolvedVmpOverLimit = event.detail.overLimit;
-    }
-    function getShowPercentilesParam(mode, trusts, showPercentilesValue) {
-        const hasTrusts = Array.isArray(trusts) && trusts.length > 0;
-        if (mode === 'trust' && hasTrusts && showPercentilesValue === true) {
-            return 'true';
-        }
-        return null;
-    }
-
-
-    function encodeQuantityType(quantityType) {
-        if (!quantityType) return null;
-        const trimmed = quantityType.trim();
-        return QUANTITY_TYPE_CODES[trimmed] || null;
-    }
-
-
-    function updateAnalysisUrl(products = [], trusts = [], quantityType = null, mode = null, showPercentiles = null, excludedVmps = []) {
-        if (typeof window === 'undefined') return;
-
-        const params = {};
-
-        const productGroups = {};
-        products.forEach(item => {
-            if (!item?.code || !item?.type) return;
-            const typeKey = item.type.toLowerCase();
-            const paramName = PRODUCT_PARAM_BY_TYPE[typeKey];
-            if (!paramName) return;
-
-            if (!productGroups[paramName]) productGroups[paramName] = [];
-            if (!productGroups[paramName].includes(item.code)) {
-                productGroups[paramName].push(item.code);
-            }
-        });
-
-        Object.entries(productGroups).forEach(([paramName, codes]) => {
-            if (codes.length > 0) {
-                params[paramName] = formatArrayParam(codes);
-            }
-        });
-
-        const trustCodes = trusts.map(name => organisationSearchStore.getOrgCode(name)).filter(Boolean);
-        if (trustCodes.length > 0) {
-            params[ANALYSIS_TRUSTS_PARAM] = formatArrayParam(trustCodes);
-        }
-
-        if (quantityType) {
-            const encodedQuantity = encodeQuantityType(quantityType);
-            if (encodedQuantity) {
-                params[ANALYSIS_QUANTITY_PARAM] = encodedQuantity;
-            }
-        }
-
-        if (mode) {
-            const normalisedMode = normaliseMode(mode);
-            const shouldForceModeParam = showPercentiles === 'true';
-            if (normalisedMode && (normalisedMode !== 'trust' || shouldForceModeParam)) {
-                params[ANALYSIS_MODE_PARAM] = normalisedMode;
-            }
-        }
-
-        if (showPercentiles !== null) {
-            params[ANALYSIS_PERCENTILES_PARAM] = showPercentiles;
-        }
-
-        if (excludedVmps.length > 0) {
-            params[ANALYSIS_EXCLUDED_VMPS_PARAM] = formatArrayParam(excludedVmps);
-        }
-
-        setUrlParams(params, SUPPORTED_ANALYSIS_PARAMS);
-    }
-
-    function buildValidationParams(urlParams) {
-        const queryParams = new URLSearchParams();
-
-        PRODUCT_TYPE_ORDER.forEach(type => {
-            const paramName = PRODUCT_PARAM_BY_TYPE[type];
-            const paramValue = urlParams.get(paramName);
-            if (paramValue?.trim()) {
-                queryParams.append(paramName, paramValue);
-            }
-        });
-
-        [ANALYSIS_TRUSTS_PARAM, ANALYSIS_QUANTITY_PARAM, ANALYSIS_MODE_PARAM,
-         ANALYSIS_PERCENTILES_PARAM, ANALYSIS_EXCLUDED_VMPS_PARAM].forEach(param => {
-            const value = urlParams.get(param);
-            if (value?.trim()) {
-                queryParams.append(param, value.trim());
-            }
-        });
-
-        return queryParams;
     }
 
     function handleValidationResponse(data) {
@@ -226,56 +168,6 @@
         return true;
     }
 
-    function updateStoresFromValidation(data) {
-        if (data.valid_products?.length > 0) {
-            analyseOptions.update(options => ({
-                ...options,
-                selectedVMPs: data.valid_products
-            }));
-
-            if (data.quantity_type) {
-                analyseOptions.setQuantityType(data.quantity_type.name);
-                selectedQuantityType = data.quantity_type.name;
-                if (data.quantity_type.code) {
-                    setUrlParams({ [ANALYSIS_QUANTITY_PARAM]: data.quantity_type.code }, [ANALYSIS_QUANTITY_PARAM]);
-                }
-            } else {
-                selectQuantityType(data.valid_products);
-            }
-        }
-
-        if (data.valid_trusts?.length > 0) {
-            const trustNames = data.valid_trusts.map(trust => trust.ods_name);
-            organisationSearchStore.updateSelection(trustNames);
-            analyseOptions.setSelectedOrganisations(trustNames);
-        }
-
-        const hasValidTrusts = Array.isArray(data.valid_trusts) && data.valid_trusts.length > 0;
-        const responseExcludedVmps = Array.isArray(data.excluded_vmps)
-            ? Array.from(new Set(data.excluded_vmps.map(String).filter(Boolean))).sort()
-            : [];
-
-
-        let finalShowPercentiles;
-        if (urlState.showPercentiles === 'true') {
-            finalShowPercentiles = true;
-        } else if (urlState.showPercentiles === 'false') {
-            finalShowPercentiles = false;
-        } else if (data.mode === 'trust' && hasValidTrusts) {
-            finalShowPercentiles = data.show_percentiles ?? false;
-        } else {
-            finalShowPercentiles = !hasValidTrusts;
-        }
-
-        resultsStore.update(store => ({
-            ...store,
-            showPercentiles: finalShowPercentiles,
-            excludedVmps: responseExcludedVmps
-        }));
-
-        urlState.excludedVmps = responseExcludedVmps;
-    }
-
     async function hydrateFromUrl() {
         if (urlState.isHydrated || typeof window === 'undefined') {
             urlState.suppressSync = false;
@@ -286,37 +178,96 @@
 
         try {
             const urlParams = getUrlParams();
-            urlState.mode = normaliseMode(urlParams.get(ANALYSIS_MODE_PARAM));
-            urlState.showPercentiles = urlParams.get(ANALYSIS_PERCENTILES_PARAM);
+            const plan = planAnalysisHydrate({
+                urlParams,
+                regionsHierarchy: $organisationSearchStore.regionsHierarchy || [],
+                cancerAlliances:
+                    typeof organisationSearchStore.getCancerAlliances === 'function'
+                        ? organisationSearchStore.getCancerAlliances()
+                        : [],
+                decodeTrustTypeFromUrl,
+            });
 
-            const queryParams = buildValidationParams(urlParams);
-            if (!queryParams.toString()) {
+            const hydrateScope = isAuth ? plan.scope : ANALYSIS_SCOPE.ALL;
+            selectedScopeFilters = isAuth ? plan.scopeFilters : createEmptyScopeFilters();
+            handleScopeChange(hydrateScope);
+            if (isAuth && plan.shouldShowAdvancedOptions) {
+                showAdvancedOptions = true;
+            }
+            urlState.mode = plan.mode;
+            urlState.showPercentiles = plan.showPercentilesRaw;
+            analyseOptions.setSelectedChartRegions(plan.chartRegions);
+            analyseOptions.setSelectedChartIcbs(plan.chartIcbs);
+
+            if (!plan.validationQuery.toString()) {
                 urlState.suppressSync = false;
                 return;
             }
 
-            const response = await fetch(`/api/validate-analysis-params/?${queryParams}`, {
+            const response = await fetch(`/api/validate-analysis-params/?${plan.validationQuery}`, {
                 method: 'GET',
                 headers: { 'Content-Type': 'application/json' }
             });
 
-            if (response.ok) {
-                const data = await response.json();
-                const isValid = handleValidationResponse(data);
+            if (!response.ok) {
+                console.error('Failed to validate URL parameters:', response.status);
+                return;
+            }
 
-                if (isValid) {
-                    updateStoresFromValidation(data);
+            const data = await response.json();
+            if (!handleValidationResponse(data)) {
+                return;
+            }
 
+            const patch = planValidationStorePatch({
+                data,
+                scope: hydrateScope,
+                mode: plan.mode,
+                showPercentilesRaw: plan.showPercentilesRaw,
+                hasExplicitTrustSelection: plan.hasExplicitTrustSelection,
+            });
+
+            const { excludedVmps } = await finishValidatedHydrate({
+                patch,
+                selectedScope: hydrateScope,
+                selectedScopeFilters: isAuth ? plan.scopeFilters : createEmptyScopeFilters(),
+                analyseOptions,
+                organisationSearchStore,
+                resultsStore,
+                modeSelectorStore,
+                applyQuantityType: async (hydratePatch) => {
+                    if (hydratePatch.quantityType) {
+                        analyseOptions.setQuantityType(hydratePatch.quantityType.name);
+                        selectedQuantityType = hydratePatch.quantityType.name;
+                        if (hydratePatch.quantityType.code) {
+                            setUrlParams(
+                                { [ANALYSIS_QUANTITY_PARAM]: hydratePatch.quantityType.code },
+                                [ANALYSIS_QUANTITY_PARAM]
+                            );
+                        }
+                        await selectQuantityType(hydratePatch.selectedVMPs, { preserveSelection: true });
+                    } else {
+                        await selectQuantityType(hydratePatch.selectedVMPs);
+                    }
+                },
+                cleanupUrlParams: () => {
                     if (typeof window !== 'undefined') {
                         cleanupUrl(SUPPORTED_ANALYSIS_PARAMS);
                     }
+                },
+                waitForUi: () => tick(),
+            });
 
-                    await tick();
-                    runAnalysis();
-                }
-            } else {
-                console.error('Failed to validate URL parameters:', response.status);
+            if (!isAuth && patch.selectedOrganisations?.length > 0) {
+                organisationSearchStore.updateSelection(patch.selectedOrganisations);
             }
+
+            urlState.excludedVmps = excludedVmps;
+
+            const overlayFromUrl = hydrateScope === ANALYSIS_SCOPE.TRUST
+                ? (patch.selectedOrganisations || []).slice(0, 1)
+                : (patch.selectedOrganisations || []);
+            await runAnalysis({ overlayOrganisations: overlayFromUrl });
         } catch (error) {
             console.error('Failed to hydrate analysis selections from URL:', error);
         } finally {
@@ -355,7 +306,7 @@
 
     const csrftoken = getCookie('csrftoken');
     
-    async function selectQuantityType(selectedVMPs) {
+    async function selectQuantityType(selectedVMPs, { preserveSelection = false } = {}) {
 
         if (!selectedVMPs || selectedVMPs.length === 0) {
 
@@ -386,9 +337,11 @@
             
             const data = await response.json();
             
-            selectedQuantityType = data.selected_quantity_type;
             recommendedQuantityTypes = data.recommended_quantity_types || [];
-            analyseOptions.setQuantityType(selectedQuantityType);
+            if (!preserveSelection) {
+                selectedQuantityType = data.selected_quantity_type;
+                analyseOptions.setQuantityType(selectedQuantityType);
+            }
             
         } catch (error) {
             console.error('Error selecting quantity type:', error);
@@ -421,32 +374,57 @@
         return resolvedProducts;
     }
 
-    async function runAnalysis() {
+    async function runAnalysis(options = {}) {
         if (isAnalysisRunning) return;
+
+        const runScope = isAuth ? selectedScope : ANALYSIS_SCOPE.ALL;
+        const runScopeFilters = isAuth ? selectedScopeFilters : createEmptyScopeFilters();
 
         errorMessage = '';
 
-        if (!selectedVMPs || selectedVMPs.length === 0) {
-            errorMessage = "Please select at least one product or ingredient.";
+        const validationError = validateAnalysisRun({
+            selectedVMPs,
+            selectedScope: runScope,
+            selectedTrusts,
+            selectedScopeFilters: runScopeFilters,
+            availableItems: $organisationSearchStore.availableItems || [],
+        });
+        if (validationError) {
+            errorMessage = validationError;
             return;
         }
 
-        
         modeSelectorStore.reset();
-
         isAnalysisRunning = true;
         dispatch('analysisStart');
-        
+
+        const hasExplicitOverlay = Object.prototype.hasOwnProperty.call(options, 'overlayOrganisations');
+        const legacyOverlayOrganisations = !isAuth && !hasExplicitOverlay
+            ? ($organisationSearchStore.selectedItems || [])
+            : options.overlayOrganisations;
+
+        const plan = buildAnalysisRunPlan({
+            selectedScope: runScope,
+            selectedItems: $organisationSearchStore.selectedItems || [],
+            availableItems: $organisationSearchStore.availableItems || [],
+            allItems: $organisationSearchStore.items || [],
+            selectedTrusts,
+            getOrgCode: (name) => organisationSearchStore.getOrgCode(name),
+            overlayOrganisations: legacyOverlayOrganisations,
+        });
+
         if (typeof window !== 'undefined' && window.plausible) {
             window.plausible('Analysis Run', {
                 props: {
                     all_products: selectedVMPs.map(p => p.code).join(','),
-                    all_organisations: $organisationSearchStore.selectedItems.join(','),
+                    // Names only for single-trust; larger cohorts are counted via organisation_count.
+                    all_organisations: runScope === ANALYSIS_SCOPE.TRUST ? plan.cohortTrusts.join(',') : '',
                     product_count: selectedVMPs.length.toString(),
-                    organisation_count: $organisationSearchStore.selectedItems.length.toString(),
+                    organisation_count: plan.cohortTrusts.length.toString(),
                     search_type: searchType,
                     quantity_type: selectedQuantityType || 'auto',
                     analysis_mode: effectiveMode || 'trust',
+                    analysis_scope: runScope,
 
                     used_url_params: urlState.isHydrated && Object.keys(urlState).some(key => {
                         const value = urlState[key];
@@ -456,62 +434,31 @@
                 }
             });
         }
-        
-        let endpoint = '/api/get-quantity-data/';
-        
+
         try {
             const resolvedProducts = await resolveProductsToVMPs(selectedVMPs);
-
-            const response = await fetch(endpoint, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': csrftoken
-                },
-                body: JSON.stringify(
-                    buildAnalysisRequestPayload({
-                        selectedProducts: resolvedProducts,
-                        quantityType: $analyseOptions.quantityType,
-                    })
-                )
+            const payload = await executeAnalysisFetch({
+                csrftoken,
+                resolvedProducts,
+                quantityType: $analyseOptions.quantityType,
+                selectedScope: runScope,
+                odsCodes: plan.odsCodes,
             });
 
-            if (!response.ok) {
-                const data = await response.json();
-                throw new Error(data.error || `HTTP error! status: ${response.status}`);
-            }
-
-            const data = await response.json();
-
-            const payload = { months: data.months ?? [], items: data.items ?? [] };
-
-            analyseOptions.runAnalysis({
+            const complete = completeAnalysisRun({
+                plan,
+                payload,
                 selectedVMPs,
                 searchType,
-                organisations: $organisationSearchStore.selectedItems
-            });
-
-            const updateOptions = {
-                searchType,
                 quantityType: $analyseOptions.quantityType,
-                selectedOrganisations: $organisationSearchStore.selectedItems,
-            };
-
-            if (urlState.showPercentiles !== null) {
-                updateOptions.showPercentiles = urlState.showPercentiles === 'true';
-            }
-
-            if (urlState.excludedVmps.length > 0) {
-                updateOptions.excludedVmps = urlState.excludedVmps;
-            }
-
-            updateResults(payload, updateOptions);
-
-            dispatch('analysisComplete', { 
-                data: payload,
-                searchType,
-                selectedOrganisations: $organisationSearchStore.selectedItems
+                selectedScope: runScope,
+                selectedScopeFilters: runScopeFilters,
+                showPercentilesFromUrl: urlState.showPercentiles,
+                excludedVmps: urlState.excludedVmps,
+                analyseOptions,
+                updateResults,
             });
+            dispatch('analysisComplete', complete);
         } catch (error) {
             console.error("Error fetching filtered data:", error);
             errorMessage = "An error occurred while fetching data. Please try again.";
@@ -533,22 +480,44 @@
     }
 
     function handleODSSelection(event) {
-        const { selectedItems, usedOrganisationSelection } = event.detail;
+        const selectedItems = event.detail.selectedItems || [];
+        const usedOrganisationSelection = event.detail.usedOrganisationSelection;
         const previouslyHadTrusts = selectedTrusts.length > 0;
-        const willHaveTrusts = Array.isArray(selectedItems) && selectedItems.length > 0;
+        const willHaveTrusts = selectedItems.length > 0;
 
         organisationSearchStore.updateSelection(selectedItems, usedOrganisationSelection);
-        analyseOptions.setSelectedOrganisations(selectedItems);
 
-        if (!previouslyHadTrusts && willHaveTrusts) {
+        if (!isAuth) {
+            analyseOptions.setSelectedOrganisations(selectedItems);
+            analyseOptions.setRememberedOverlayOrganisations(selectedItems);
+
             if (urlState.showPercentiles === null) {
-                resultsStore.update(store => ({ ...store, showPercentiles: false }));
-            }
-        } else if (previouslyHadTrusts && !willHaveTrusts) {
-            if (urlState.showPercentiles === null) {
-                resultsStore.update(store => ({ ...store, showPercentiles: true }));
+                if (!previouslyHadTrusts && willHaveTrusts) {
+                    resultsStore.update(store => ({ ...store, showPercentiles: false }));
+                } else if (previouslyHadTrusts && !willHaveTrusts) {
+                    resultsStore.update(store => ({ ...store, showPercentiles: true }));
+                }
             }
         }
+    }
+
+    function handleScopeChange(scope) {
+        selectedScope = scope;
+
+        if (
+            scope === ANALYSIS_SCOPE.ALL
+            || scope === ANALYSIS_SCOPE.NATIONAL
+            || scope === ANALYSIS_SCOPE.TRUST
+        ) {
+            organisationSearchStore.setAvailableItems(Array.from($organisationSearchStore.items || []));
+            organisationSearchStore.setFiltersApplied(false);
+        }
+
+        if (scope === ANALYSIS_SCOPE.TRUST || scope === ANALYSIS_SCOPE.GROUP) {
+            organisationSearchStore.setFilterType('trust');
+        }
+
+        organisationSearchStore.updateSelection([]);
     }
 
     function toggleAdvancedOptions() {
@@ -577,10 +546,16 @@
         }));
         organisationSearchStore.updateSelection([]);
         analyseOptions.setSelectedOrganisations([]);
+        analyseOptions.setRememberedOverlayOrganisations([]);
+        analyseOptions.setSelectedChartRegions(allOverlaySelection());
+        analyseOptions.setSelectedChartIcbs(allOverlaySelection());
         
         recommendedQuantityTypes = [];
         showAdvancedOptions = false;
         selectedQuantityType = null;
+        selectedScope = ANALYSIS_SCOPE.ALL;
+        selectedScopeFilters = createEmptyScopeFilters();
+        organisationSearchStore.setFilterType('trust');
         modeSelectorStore.reset();
         urlState = {
             mode: null,
@@ -593,7 +568,10 @@
         resultsStore.update(store => ({
             ...store,
             showPercentiles: true,
-            excludedVmps: []
+            excludedVmps: [],
+            scope: ANALYSIS_SCOPE.ALL,
+            scopeFilters: createEmptyScopeFilters(),
+            inScopeTrusts: []
         }));
         dispatch('urlValidationErrors', { errors: [] });
 
@@ -615,6 +593,13 @@
     function handleClearAnalysis() {
         resetSelections();
         dispatch('analysisClear');
+    }
+
+    function handleScopeFiltersChange(event) {
+        selectedScopeFilters = normaliseScopeFilters(event?.detail || {});
+        if (hasAnyScopeFilters(selectedScopeFilters)) {
+            errorMessage = '';
+        }
     }
 
 </script>
@@ -666,6 +651,7 @@
             </div>
           </div>
 
+          {#if !isAuth}
           <!-- Trust Selection -->
           <div class="grid gap-0">
             <div class="flex items-center">
@@ -681,7 +667,7 @@
                   ring-1 ring-black ring-opacity-5 p-4">
                   <div class="text-sm text-gray-500 space-y-3">
                     <div class="space-y-1 text-xs">
-                      <p>{#if isAuth}Select NHS Trusts to filter the analysis.{:else}Select up to 10 NHS Trusts.{/if}</p>
+                      <p>Select up to 10 NHS Trusts.</p>
                       <ul>
                         <li><strong>No trusts selected:</strong> Shows national data with regional/ICB breakdowns available</li>
                         <li><strong>Trusts selected:</strong> Filters analysis results to the selected trusts</li>
@@ -698,26 +684,17 @@
               </div>
             </div>
             <div class="relative min-w-0">
-              {#if isAuth}
-                <OrganisationSearchFiltered
-                  source={organisationSearchStore}
-                  overlayMode={false}
-                  on:selectionChange={handleODSSelection}
-                  showTitle={false}
-                  filterAutoSelectsAll={false}
-                />
-              {:else}
-                <OrganisationSearch
-                  source={organisationSearchStore}
-                  overlayMode={false}
-                  on:selectionChange={handleODSSelection}
-                  maxItems={10}
-                  hideSelectAll={true}
-                  showTitle={false}
-                />
-              {/if}
+              <OrganisationSearch
+                source={organisationSearchStore}
+                overlayMode={false}
+                on:selectionChange={handleODSSelection}
+                maxItems={10}
+                hideSelectAll={true}
+                showTitle={false}
+              />
             </div>
           </div>
+          {/if}
 
         </div>
 
@@ -736,8 +713,21 @@
 
               {#if showAdvancedOptions}
                 <div class="space-y-4">
+                  {#if isAuth}
+                    <AnalysisScopePanel
+                      {selectedScope}
+                      {selectedScopeFilters}
+                      source={organisationSearchStore}
+                      on:scopeChange={(e) => handleScopeChange(e.detail)}
+                      on:filtersChange={handleScopeFiltersChange}
+                      on:selectionChange={handleODSSelection}
+                    />
+                  {/if}
+
                   <div class="space-y-3">
-                    <h3 class="text-base sm:text-lg font-semibold text-oxford">Quantity Type (optional)</h3>
+                    <h3 class="text-base sm:text-lg font-semibold text-oxford">
+                      {isAuth ? 'Quantity Type' : 'Quantity Type (optional)'}
+                    </h3>
                     <p class="text-sm text-oxford">
                       There are different ways to <a href="/faq/#what-does-quantity-mean" class="underline font-semibold" target="_blank">measure the quantity of medicines issued</a>. The most appropriate quantity for the selected products is automatically selected (<a href="/faq/#how-is-the-quantity-type-used-for-an-analysis-chosen" class="underline font-semibold" target="_blank">see how in the FAQs</a>). If you would like to select an alternative quantity type, you can do so below.
                     </p>
@@ -815,7 +805,7 @@
             <!-- Action Buttons -->
             <div class="flex gap-2 justify-between">
               <button
-                on:click={runAnalysis}
+                on:click={() => runAnalysis()}
                 disabled={isAnalysisRunning || isSelectingQuantityTypes || resolvedVmpOverLimit}
                 class="w-64 px-6 sm:px-8 py-2 sm:py-2.5 bg-oxford-50 text-oxford-600 font-semibold rounded-md hover:bg-oxford-100 transition-colors duration-200
                      disabled:bg-gray-50 disabled:text-gray-400 disabled:cursor-not-allowed"

--- a/src/components/analyse/analyse/AnalysisBuilder.svelte
+++ b/src/components/analyse/analyse/AnalysisBuilder.svelte
@@ -498,6 +498,7 @@
                     resultsStore.update(store => ({ ...store, showPercentiles: true }));
                 }
             }
+            dispatch('overlaySelectionChange');
         }
     }
 

--- a/src/components/analyse/analyse/AnalysisScopePanel.svelte
+++ b/src/components/analyse/analyse/AnalysisScopePanel.svelte
@@ -1,0 +1,85 @@
+<svelte:options runes={false} />
+
+<script>
+    import { createEventDispatcher } from 'svelte';
+    import OrganisationSearch from '../../common/OrganisationSearch.svelte';
+    import TrustScopeFilterPanel from '../../common/TrustScopeFilterPanel.svelte';
+
+    export let selectedScope = 'all';
+    export let selectedScopeFilters = {};
+    export let source;
+
+    const dispatch = createEventDispatcher();
+
+    function handleScopeChange(scope) {
+        dispatch('scopeChange', scope);
+    }
+</script>
+
+<div class="space-y-3">
+  <h3 class="text-base sm:text-lg font-semibold text-oxford">Scope</h3>
+  <p class="text-sm text-oxford">
+    The scope of an analysis specifies the NHS trusts to be included and the level of reporting. See <a href="/faq/#what-is-analysis-scope" class="underline font-semibold" target="_blank">the FAQs</a> for more details.
+  </p>
+  <div class="relative min-w-0">
+    <fieldset class="space-y-2 text-sm text-oxford">
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input
+          type="radio"
+          name="analysis-scope"
+          checked={selectedScope === 'all'}
+          on:change={() => handleScopeChange('all')}
+        />
+        <span>All trusts</span>
+      </label>
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input
+          type="radio"
+          name="analysis-scope"
+          checked={selectedScope === 'national'}
+          on:change={() => handleScopeChange('national')}
+        />
+        <span>National</span>
+      </label>
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input
+          type="radio"
+          name="analysis-scope"
+          checked={selectedScope === 'trust'}
+          on:change={() => handleScopeChange('trust')}
+        />
+        <span>Single trust</span>
+      </label>
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input
+          type="radio"
+          name="analysis-scope"
+          checked={selectedScope === 'group'}
+          on:change={() => handleScopeChange('group')}
+        />
+        <span>Trust group</span>
+      </label>
+    </fieldset>
+
+    {#if selectedScope === 'trust'}
+      <div class="mt-3">
+        <OrganisationSearch
+          {source}
+          overlayMode={false}
+          on:selectionChange
+          maxItems={1}
+          hideSelectAll={true}
+          showTitle={false}
+        />
+      </div>
+    {:else if selectedScope === 'group'}
+      <div class="mt-3 min-w-0 max-w-full overflow-x-hidden">
+        <TrustScopeFilterPanel
+          {source}
+          initialFilters={selectedScopeFilters}
+          on:filtersChange
+        />
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/components/analyse/lib/analyseData.js
+++ b/src/components/analyse/lib/analyseData.js
@@ -1,16 +1,8 @@
-import { chartConfig } from './chartConfig.js';
-import { normaliseDDDUnit } from './utils';
+import { chartConfig } from '../../../utils/chartConfig.js';
+import { normaliseDDDUnit } from '../../../utils/utils.js';
 import pluralize from 'pluralize';
+import { ANALYSIS_SCOPE, getNationalModeLabel } from './analysisScope.js';
 
-export function buildAnalysisRequestPayload({
-    selectedProducts = [],
-    quantityType = null,
-}) {
-    return {
-        names: selectedProducts,
-        quantity_type: quantityType,
-    };
-}
 
 export class ChartDataProcessor {
     constructor(data, aggregatedData, options = {}) {
@@ -83,8 +75,6 @@ export class ChartDataProcessor {
             this.rawData.filter(item => selectedOrganisations.includes(item.organisation__ods_name)) :
             [];
 
-        // When trusts are selected, ensure all selected trusts appear in orgData
-        // so they show in the chart legend
         if (selectedOrganisations.length > 0) {
             selectedOrganisations.forEach(org => {
                 if (org && !orgData[org]) {
@@ -263,9 +253,11 @@ export class ChartDataProcessor {
             }
         });
 
+        const scope = this.options.scope || ANALYSIS_SCOPE.ALL;
+
         return {
             datasets: [{
-                label: 'National Total',
+                label: getNationalModeLabel(scope, { longForm: true }),
                 data: nationalData,
                 color: '#1e40af',
                 strokeOpacity: 1,
@@ -424,136 +416,351 @@ export class ChartDataProcessor {
     }
 }
 
-export class ViewModeCalculator {
-    constructor(resultsStore, analyseOptions, organisationSearchStore, vmps) {
-        this.resultsStore = resultsStore;
-        this.analyseOptions = analyseOptions;
-        this.organisationSearchStore = organisationSearchStore;
-        this.vmps = vmps;
-    }
 
-    calculateAvailableModes() {
-        const modes = [];
-        
-        // Only add modes if there are VMPs with valid data
-        if (this.vmps && this.vmps.length > 0) {
-            modes.push({ value: 'trust', label: 'NHS Trust' });
-            
-            modes.push(...this.getAggregationModes());
-            
-            modes.push(...this.getProductModes());
-        }
-        
-        return modes;
-    }
+export function shouldIncludeDate(date, period, latestDate) {
+    if (period === 'all') return true;
 
-    hasSelectedOrganisations() {
-        return this.analyseOptions.selectedOrganisations && 
-               this.analyseOptions.selectedOrganisations.length > 0;
-    }
+    const dataDate = new Date(date);
+    const dataDateStr = dataDate.toISOString().split('T')[0];
+    const latestDateStr = latestDate ? latestDate.toISOString().split('T')[0] : null;
 
-    hasSelectedOrganisationsWithData() {
-        if (!this.hasSelectedOrganisations()) return false;
-
-        const selectedOrgNames = new Set(this.analyseOptions.selectedOrganisations);
-
-        const selectedOrganisationsWithData = this.resultsStore.analysisData
-            ?.filter(item => {
-                const orgName = item.organisation__ods_name;
-                const isSelected = selectedOrgNames.has(orgName);
-                const hasData = item.data && Array.isArray(item.data) &&
-                    item.data.some(v => v > 0 && !isNaN(parseFloat(v)));
-                return isSelected && hasData;
-            }) || [];
-
-        return selectedOrganisationsWithData.length >= 1;
-    }
-
-    getAggregationModes() {
-        const modes = [];
-        
-        // Only show aggregation modes if no trusts are selected
-        if (this.hasSelectedOrganisations()) {
-            return modes;
-        }
-        
-        if (!this.resultsStore.aggregatedData) return modes;
-        
-        const { regions = {}, icbs = {}, national = {} } = this.resultsStore.aggregatedData;
-        
-        if (icbs && Object.keys(icbs).length > 1) {
-            modes.push({ value: 'icb', label: 'ICB' });
-        }
-        
-        if (regions && Object.keys(regions).length > 1) {
-            modes.push({ value: 'region', label: 'Region' });
-        }
-        
-        if (national && Object.keys(national).length > 0) {
-            modes.push({ value: 'national', label: 'National' });
-        }
-
-        if (this.resultsStore.analysisData) {
-            const mappedICBs = new Set(
-                this.resultsStore.analysisData.map(item => item.organisation__icb).filter(Boolean)
-            );
-
-            if (mappedICBs.size > 1 && !modes.some(m => m.value === 'icb')) {
-                modes.push({ value: 'icb', label: 'ICB' });
+    switch (period) {
+        case 'latest_month':
+            if (!latestDate) return false;
+            return dataDate.getMonth() === latestDate.getMonth() &&
+                   dataDate.getFullYear() === latestDate.getFullYear();
+        case 'latest_year':
+            if (!latestDate) return false;
+            return dataDate.getFullYear() === latestDate.getFullYear();
+        case 'current_fy':
+            if (!latestDate) return false;
+            const fyStart = new Date(latestDate.getFullYear(), 3, 1); // April 1st
+            if (latestDate < fyStart) {
+                fyStart.setFullYear(fyStart.getFullYear() - 1);
             }
 
-            const uniqueRegions = new Set(this.resultsStore.analysisData.map(item => item.organisation__region).filter(Boolean));
-            if (uniqueRegions.size > 1 && !modes.some(m => m.value === 'region')) {
-                modes.push({ value: 'region', label: 'Region' });
-            }
-        }
-        
-        return modes;
-    }
+            const fyStartStr = fyStart.toISOString().split('T')[0];
 
-    getProductModes() {
-        const modes = [];
-        
-        if (!this.vmps || this.vmps.length === 0) return modes;
+            return dataDateStr >= fyStartStr && dataDateStr <= latestDateStr;
+        case 'last_12_months':
+            if (!latestDate) return false;
+            const twelveMonthsAgo = new Date(latestDate);
+            twelveMonthsAgo.setMonth(twelveMonthsAgo.getMonth() - 11);
 
-        if (this.vmps.length > 1) {
-            modes.push({ value: 'product', label: 'Product' });
-        }
+            const startDateStr = twelveMonthsAgo.toISOString().split('T')[0];
 
-        const uniqueVtms = new Set(this.vmps.map(vmp => vmp.vtm).filter(vtm => vtm && vtm !== '-' && vtm !== 'nan'));
-        if (uniqueVtms.size > 1) {
-            modes.push({ value: 'productGroup', label: 'Product Group' });
-        }
-
-        const uniqueIngredients = new Set(
-            this.vmps.flatMap(vmp => (vmp.ingredients || []))
-                .filter(ing => ing && ing !== '-' && ing !== 'nan')
-        );
-        if (uniqueIngredients.size > 1) {
-            modes.push({ value: 'ingredient', label: 'Ingredient' });
-        }
-
-        const uniqueUnits = new Set(
-            this.vmps.flatMap(vmp => Array.from(vmp.units || []))
-                .filter(unit => unit && unit !== '-' && unit !== 'nan')
-                .map(unit => normaliseDDDUnit(unit))
-        );
-        if (uniqueUnits.size > 1) {
-            modes.push({ value: 'unit', label: 'Unit' });
-        }
-
-        return modes;
+            return dataDateStr >= startDateStr && dataDateStr <= latestDateStr;
+        default:
+            return true;
     }
 }
 
-export function selectDefaultMode(availableModes, hasSelectedOrganisations = false) {
-    const trustMode = availableModes.find(m => m.value === 'trust');
-    if (trustMode) return trustMode.value;
-    
-    const nationalMode = availableModes.find(m => m.value === 'national');
-    if (nationalMode) return nationalMode.value;
-    
-    return availableModes[0]?.value || 'trust';
+function getDefaultUnitsForZeroTotals(data) {
+    const units = new Set();
+    const addUnit = (u) => {
+        const n = normaliseDDDUnit(u || '');
+        if (n) units.add(n);
+    };
+
+    data?.forEach(item => addUnit(item.unit));
+
+    const arr = [...units];
+    return arr.length ? arr.map(unit => ({ unit, quantity: 0 })) : null;
+}
+
+export function processTableDataByMode(data, mode, period, aggregatedData, latestDate, selectedOrganisations = [], allOrganisations = [], months = [], regionsHierarchy = [], scope = ANALYSIS_SCOPE.ALL) {
+    if (!data?.length && !aggregatedData) return [];
+
+    const defaultUnits = getDefaultUnitsForZeroTotals(data);
+    const selectedProductCodes = data?.length
+        ? new Set(data.map(item => item.vmp__code).filter(Boolean))
+        : null;
+
+    if (['region', 'icb', 'national'].includes(mode) && aggregatedData) {
+        return processAggregatedMode(aggregatedData, mode, period, latestDate, selectedProductCodes, regionsHierarchy, defaultUnits);
+    }
+
+    if (mode === 'trust') {
+        return processOrganisationModeWithAggregation(data, period, latestDate, selectedOrganisations, allOrganisations, months, defaultUnits, scope);
+    }
+
+    return processRawDataMode(data, mode, period, latestDate, selectedOrganisations, months);
+}
+
+function processOrganisationModeWithAggregation(data, period, latestDate, selectedOrganisations, allOrganisations, months = [], defaultUnits = null, scope = ANALYSIS_SCOPE.ALL) {
+
+    const filteredData = data || [];
+
+    const selectedSet = new Set(selectedOrganisations);
+    const selectedTrusts = {};
+    const otherTrusts = {};
+    const selectedTotals = { total: 0, units: {} };
+    const otherTotals = { total: 0, units: {} };
+
+    allOrganisations.forEach(orgName => {
+        const isSelected = selectedSet.has(orgName);
+        const targetGroup = isSelected ? selectedTrusts : otherTrusts;
+        targetGroup[orgName] = { total: 0, units: {} };
+    });
+
+    filteredData.forEach(item => {
+        const orgName = item.organisation__ods_name || 'Unknown Organisation';
+        const isSelected = selectedSet.has(orgName);
+        const targetGroup = isSelected ? selectedTrusts : otherTrusts;
+        const targetTotals = isSelected ? selectedTotals : otherTotals;
+
+        if (targetGroup[orgName] !== undefined) {
+            item.data?.forEach((value, i) => {
+                if (i >= months.length || !shouldIncludeDate(months[i], period, latestDate)) return;
+                const parsedQuantity = parseFloat(value) || 0;
+                const normalisedUnit = normaliseDDDUnit(item.unit || '');
+
+                targetGroup[orgName].total += parsedQuantity;
+                if (!targetGroup[orgName].units[normalisedUnit]) {
+                    targetGroup[orgName].units[normalisedUnit] = 0;
+                }
+                targetGroup[orgName].units[normalisedUnit] += parsedQuantity;
+
+                targetTotals.total += parsedQuantity;
+                if (!targetTotals.units[normalisedUnit]) {
+                    targetTotals.units[normalisedUnit] = 0;
+                }
+                targetTotals.units[normalisedUnit] += parsedQuantity;
+            });
+        }
+    });
+
+    const results = [];
+
+    function countTotalOrgs(trustsGroup) {
+        return Object.keys(trustsGroup).length;
+    }
+
+    const toUnitsArray = (unitsObj, fallback) => {
+        const entries = Object.entries(unitsObj).sort(([, a], [, b]) => b - a);
+        if (entries.length === 0 && fallback?.length) {
+            return fallback;
+        }
+        if (entries.length === 0) {
+            return [{ unit: '--', quantity: 0 }];
+        }
+        return entries.map(([unit, quantity]) => ({ unit, quantity }));
+    };
+
+    if (Object.keys(selectedTrusts).length > 0) {
+        const totalSelectedCount = countTotalOrgs(selectedTrusts);
+        
+        results.push({
+            key: totalSelectedCount === 1
+                ? 'Selected trust (1)'
+                : `Selected trusts (${totalSelectedCount})`,
+            total: selectedTotals.total,
+            units: toUnitsArray(selectedTotals.units, defaultUnits),
+            isSubtotal: true
+        });
+
+        Object.entries(selectedTrusts)
+            .sort(([, a], [, b]) => b.total - a.total)
+            .forEach(([trustName, trustData]) => {
+                let units = Object.entries(trustData.units);
+                if (units.length === 0 && defaultUnits?.length) {
+                    units = defaultUnits.map(({ unit, quantity }) => [unit, quantity]);
+                } else if (units.length === 0) {
+                    units = [['--', 0]];
+                }
+                results.push({
+                    key: trustName,
+                    total: trustData.total,
+                    units: units
+                        .sort(([, a], [, b]) => b - a)
+                        .map(([unit, quantity]) => ({ unit, quantity })),
+                    isIndividual: true
+                });
+            });
+    }
+
+    if (Object.keys(otherTrusts).length > 0) {
+        const totalOtherCount = countTotalOrgs(otherTrusts);
+        
+        const isAllTrusts = selectedOrganisations.length === 0;
+        const isFilteredScope = scope === ANALYSIS_SCOPE.GROUP;
+        let keyText;
+        if (isAllTrusts) {
+            keyText = isFilteredScope
+                ? `All in-scope trusts (${totalOtherCount})`
+                : `All trusts (${totalOtherCount})`;
+        } else {
+            keyText = isFilteredScope
+                ? `All other in-scope trusts (${totalOtherCount})`
+                : `All other trusts (${totalOtherCount})`;
+        }
+        
+        results.push({
+            key: keyText,
+            total: otherTotals.total,
+            units: toUnitsArray(otherTotals.units, defaultUnits),
+            isSubtotal: true
+        });
+
+        Object.entries(otherTrusts)
+            .sort(([, a], [, b]) => b.total - a.total)
+            .forEach(([trustName, trustData]) => {
+                let units = Object.entries(trustData.units);
+                if (units.length === 0 && defaultUnits?.length) {
+                    units = defaultUnits.map(({ unit, quantity }) => [unit, quantity]);
+                } else if (units.length === 0) {
+                    units = [['--', 0]];
+                }
+                results.push({
+                    key: trustName,
+                    total: trustData.total,
+                    units: units
+                        .sort(([, a], [, b]) => b - a)
+                        .map(([unit, quantity]) => ({ unit, quantity })),
+                    isIndividual: true
+                });
+            });
+    }
+
+    return results;
+}
+
+function processAggregatedMode(aggregatedData, mode, period, latestDate, selectedProductCodes = null, regionsHierarchy = [], defaultUnits = null) {
+    const categoryMap = {
+        'region': 'regions',
+        'icb': 'icbs',
+        'national': 'national'
+    };
+    const categoryData = aggregatedData[categoryMap[mode]] || {};
+    const resultsMap = new Map();
+
+    Object.entries(categoryData).forEach(([name, info]) => {
+        if (!info?.products) return;
+
+        const totals = { total: 0, units: {} };
+
+        Object.entries(info.products).forEach(([productKey, product]) => {
+            if (selectedProductCodes && !selectedProductCodes.has(productKey)) {
+                return;
+            }
+
+            if (!product?.data) return;
+
+            const unit = product.unit || '';
+            const normalisedUnit = normaliseDDDUnit(unit);
+
+            Object.entries(product.data).forEach(([date, quantity]) => {
+                if (!shouldIncludeDate(date, period, latestDate)) return;
+
+                const parsedQuantity = parseFloat(quantity) || 0;
+                totals.total += parsedQuantity;
+
+                if (!totals.units[normalisedUnit]) {
+                    totals.units[normalisedUnit] = 0;
+                }
+                totals.units[normalisedUnit] += parsedQuantity;
+            });
+        });
+
+        let units = Object.entries(totals.units)
+            .sort(([, a], [, b]) => b - a)
+            .map(([unit, quantity]) => ({ unit, quantity }));
+        if (units.length === 0 && defaultUnits?.length) {
+            units = defaultUnits;
+        } else if (units.length === 0) {
+            units = [{ unit: '--', quantity: 0 }];
+        }
+        resultsMap.set(name, { key: name, total: totals.total, units });
+    });
+
+    const zeroUnits = defaultUnits?.length ? defaultUnits : [{ unit: '--', quantity: 0 }];
+    let allCategoryNames = [];
+    if (mode === 'region' && regionsHierarchy.length > 0) {
+        allCategoryNames = regionsHierarchy.map(r => r.region).filter(Boolean);
+    } else if (mode === 'icb' && regionsHierarchy.length > 0) {
+        allCategoryNames = regionsHierarchy.flatMap(r => (r.icbs || []).map(i => i.name)).filter(Boolean);
+    } else if (mode === 'national') {
+        allCategoryNames = ['National'];
+    }
+    allCategoryNames.forEach(name => {
+        if (!resultsMap.has(name)) {
+            resultsMap.set(name, { key: name, total: 0, units: zeroUnits });
+        }
+    });
+
+    return Array.from(resultsMap.values()).sort((a, b) => b.total - a.total);
+}
+
+function processRawDataMode(data, mode, period, latestDate, selectedOrganisations = [], months = []) {
+    if (!data?.length) return [];
+
+    const dataToProcess = selectedOrganisations.length > 0 
+        ? data.filter(item => selectedOrganisations.includes(item.organisation__ods_name))
+        : data;
+
+    const groupedData = {};
+
+    const singleUnitPerGroup = mode === 'product' || mode === 'unit';
+
+    dataToProcess.forEach(item => {
+        const groupKey = getGroupKey(item, mode);
+        
+        if (Array.isArray(groupKey)) {
+            groupKey.forEach(key => processItemForGroup(groupedData, key, item, months, period, latestDate, singleUnitPerGroup));
+        } else {
+            processItemForGroup(groupedData, groupKey, item, months, period, latestDate, singleUnitPerGroup);
+        }
+    });
+
+    return Object.entries(groupedData)
+        .map(([key, value]) => {
+            const units = value.unit != null
+                ? [{ unit: value.unit, quantity: value.total }]
+                : Object.entries(value.units || {})
+                    .sort(([, a], [, b]) => b - a)
+                    .map(([unit, quantity]) => ({ unit, quantity }));
+            return { key, total: value.total, units };
+        })
+        .sort((a, b) => b.total - a.total);
+}
+
+function getGroupKey(item, mode) {
+    switch (mode) {
+        case 'trust':
+            return item.organisation__ods_name || 'Unknown Organisation';
+        case 'product':
+            return item.vmp__name || 'Unknown Product';
+        case 'productGroup':
+            return item.vmp__vtm__name || 'Unknown Product Group';
+        case 'ingredient':
+            return item.ingredient_names?.length > 0 ? item.ingredient_names : ['Unknown Ingredient'];
+        case 'unit':
+            return item.unit ? [item.unit] : [];
+        default:
+            return item.vmp__name || 'Unknown';
+    }
+}
+
+function processItemForGroup(groupedData, groupKey, item, months = [], period, latestDate, singleUnitPerGroup = false) {
+    if (!groupedData[groupKey]) {
+        groupedData[groupKey] = singleUnitPerGroup
+            ? { total: 0, unit: '' }
+            : { total: 0, units: {} };
+    }
+
+    const g = groupedData[groupKey];
+    item.data?.forEach((value, i) => {
+        if (i >= months.length || !shouldIncludeDate(months[i], period, latestDate)) return;
+        const parsedQuantity = parseFloat(value) || 0;
+        g.total += parsedQuantity;
+
+        if (singleUnitPerGroup) {
+            if (!g.unit && item.unit) g.unit = normaliseDDDUnit(item.unit) || item.unit;
+        } else {
+            const normalisedUnit = normaliseDDDUnit(item.unit || '');
+            g.units[normalisedUnit] = (g.units[normalisedUnit] || 0) + parsedQuantity;
+        }
+    });
 }
 
 export function processAnalysisData(months, items, selectedOrganisations = []) {
@@ -566,9 +773,16 @@ export function processAnalysisData(months, items, selectedOrganisations = []) {
         };
     }
 
+    const organisationItems = items.filter(item => item.organisation__ods_code);
+    const baseVmpItems = items.filter(item => !item.organisation__ods_code);
+    const nationalOnlyItems = organisationItems.length === 0
+        ? baseVmpItems.filter(item => Array.isArray(item.data) && item.data.length > 0)
+        : [];
+
     const groupedData = {
-        organisationItems: items.filter(item => item.organisation__ods_code),
-        baseVmpItems: items.filter(item => !item.organisation__ods_code)
+        organisationItems,
+        baseVmpItems,
+        nationalOnlyItems
     };
 
     const results = {
@@ -664,6 +878,14 @@ export function processAnalysisData(months, items, selectedOrganisations = []) {
         }
     });
 
+    groupedData.nationalOnlyItems.forEach(item => {
+        if (!item.vmp__code) return;
+
+        const productKey = item.vmp__code;
+        const timeSeriesData = denseToTimeSeries(item);
+        aggregateByCategory(results.aggregatedData.national, 'National', productKey, timeSeriesData);
+    });
+
     return results;
 }
 
@@ -687,532 +909,6 @@ function aggregateByCategory(categoryData, categoryName, productKey, timeSeriesD
     timeSeriesData.forEach(({ date, quantity }) => {
         product.data[date] = (product.data[date] || 0) + quantity;
     });
-}
-
-export function shouldIncludeDate(date, period, latestDate) {
-    if (period === 'all') return true;
-
-    const dataDate = new Date(date);
-    const dataDateStr = dataDate.toISOString().split('T')[0];
-    const latestDateStr = latestDate ? latestDate.toISOString().split('T')[0] : null;
-
-    switch (period) {
-        case 'latest_month':
-            if (!latestDate) return false;
-            return dataDate.getMonth() === latestDate.getMonth() &&
-                   dataDate.getFullYear() === latestDate.getFullYear();
-        case 'latest_year':
-            if (!latestDate) return false;
-            return dataDate.getFullYear() === latestDate.getFullYear();
-        case 'current_fy':
-            if (!latestDate) return false;
-        case 'current_fy':
-            if (!latestDate) return false;
-            const fyStart = new Date(latestDate.getFullYear(), 3, 1); // April 1st
-            if (latestDate < fyStart) {
-                fyStart.setFullYear(fyStart.getFullYear() - 1);
-            }
-
-            const fyStartStr = fyStart.toISOString().split('T')[0];
-
-            return dataDateStr >= fyStartStr && dataDateStr <= latestDateStr;
-        case 'last_12_months':
-            if (!latestDate) return false;
-            const twelveMonthsAgo = new Date(latestDate);
-            twelveMonthsAgo.setMonth(twelveMonthsAgo.getMonth() - 11);
-
-            const startDateStr = twelveMonthsAgo.toISOString().split('T')[0];
-
-            return dataDateStr >= startDateStr && dataDateStr <= latestDateStr;
-        default:
-            return true;
-    }
-}
-
-function getDefaultUnitsForZeroTotals(data) {
-    const units = new Set();
-    const addUnit = (u) => {
-        const n = normaliseDDDUnit(u || '');
-        if (n) units.add(n);
-    };
-
-    data?.forEach(item => addUnit(item.unit));
-
-    const arr = [...units];
-    return arr.length ? arr.map(unit => ({ unit, quantity: 0 })) : null;
-}
-
-export function processTableDataByMode(data, mode, period, aggregatedData, latestDate, selectedOrganisations = [], allOrganisations = [], months = [], regionsHierarchy = []) {
-    if (!data?.length && !aggregatedData) return [];
-
-    const defaultUnits = getDefaultUnitsForZeroTotals(data);
-    const selectedProductCodes = data?.length
-        ? new Set(data.map(item => item.vmp__code).filter(Boolean))
-        : null;
-
-    if (['region', 'icb', 'national'].includes(mode) && aggregatedData) {
-        return processAggregatedMode(aggregatedData, mode, period, latestDate, selectedProductCodes, regionsHierarchy, defaultUnits);
-    }
-
-    if (mode === 'trust') {
-        return processOrganisationModeWithAggregation(data, period, latestDate, selectedOrganisations, allOrganisations, months, defaultUnits);
-    }
-
-    return processRawDataMode(data, mode, period, latestDate, selectedOrganisations, months);
-}
-
-function filterItemDataByPeriod(item, period, latestDate, months) {
-    if (!Array.isArray(item.data) || !months?.length) return item;
-    return { ...item };
-}
-
-function processOrganisationModeWithAggregation(data, period, latestDate, selectedOrganisations, allOrganisations, months = [], defaultUnits = null) {
-
-    const filteredData = data ? data.map(item => filterItemDataByPeriod(item, period, latestDate, months)) : [];
-
-    const selectedSet = new Set(selectedOrganisations);
-    const selectedTrusts = {};
-    const otherTrusts = {};
-    const selectedTotals = { total: 0, units: {} };
-    const otherTotals = { total: 0, units: {} };
-
-    allOrganisations.forEach(orgName => {
-        const isSelected = selectedSet.has(orgName);
-        const targetGroup = isSelected ? selectedTrusts : otherTrusts;
-        targetGroup[orgName] = { total: 0, units: {} };
-    });
-
-    filteredData.forEach(item => {
-        const orgName = item.organisation__ods_name || 'Unknown Organisation';
-        const isSelected = selectedSet.has(orgName);
-        const targetGroup = isSelected ? selectedTrusts : otherTrusts;
-        const targetTotals = isSelected ? selectedTotals : otherTotals;
-
-        if (targetGroup[orgName] !== undefined) {
-            item.data?.forEach((value, i) => {
-                if (i >= months.length || !shouldIncludeDate(months[i], period, latestDate)) return;
-                const parsedQuantity = parseFloat(value) || 0;
-                const normalisedUnit = normaliseDDDUnit(item.unit || '');
-
-                targetGroup[orgName].total += parsedQuantity;
-                if (!targetGroup[orgName].units[normalisedUnit]) {
-                    targetGroup[orgName].units[normalisedUnit] = 0;
-                }
-                targetGroup[orgName].units[normalisedUnit] += parsedQuantity;
-
-                targetTotals.total += parsedQuantity;
-                if (!targetTotals.units[normalisedUnit]) {
-                    targetTotals.units[normalisedUnit] = 0;
-                }
-                targetTotals.units[normalisedUnit] += parsedQuantity;
-            });
-        }
-    });
-
-    const results = [];
-
-    function countTotalOrgs(trustsGroup) {
-        return Object.keys(trustsGroup).length;
-    }
-
-    const toUnitsArray = (unitsObj, fallback) => {
-        const entries = Object.entries(unitsObj).sort(([, a], [, b]) => b - a);
-        if (entries.length === 0 && fallback?.length) {
-            return fallback;
-        }
-        if (entries.length === 0) {
-            return [{ unit: '--', quantity: 0 }];
-        }
-        return entries.map(([unit, quantity]) => ({ unit, quantity }));
-    };
-
-    if (Object.keys(selectedTrusts).length > 0) {
-        const totalSelectedCount = countTotalOrgs(selectedTrusts);
-        
-        results.push({
-            key: `Selected trusts (${totalSelectedCount})`,
-            total: selectedTotals.total,
-            units: toUnitsArray(selectedTotals.units, defaultUnits),
-            isSubtotal: true
-        });
-
-        Object.entries(selectedTrusts)
-            .sort(([, a], [, b]) => b.total - a.total)
-            .forEach(([trustName, trustData]) => {
-                let units = Object.entries(trustData.units);
-                if (units.length === 0 && defaultUnits?.length) {
-                    units = defaultUnits.map(({ unit, quantity }) => [unit, quantity]);
-                } else if (units.length === 0) {
-                    units = [['--', 0]];
-                }
-                results.push({
-                    key: trustName,
-                    total: trustData.total,
-                    units: units
-                        .sort(([, a], [, b]) => b - a)
-                        .map(([unit, quantity]) => ({ unit, quantity })),
-                    isIndividual: true
-                });
-            });
-    }
-
-    if (Object.keys(otherTrusts).length > 0) {
-        const totalOtherCount = countTotalOrgs(otherTrusts);
-        
-        const isAllTrusts = selectedOrganisations.length === 0;
-        const keyText = isAllTrusts ? `All trusts (${totalOtherCount})` : `All other trusts (${totalOtherCount})`;
-        
-        results.push({
-            key: keyText,
-            total: otherTotals.total,
-            units: toUnitsArray(otherTotals.units, defaultUnits),
-            isSubtotal: true
-        });
-
-        Object.entries(otherTrusts)
-            .sort(([, a], [, b]) => b.total - a.total)
-            .forEach(([trustName, trustData]) => {
-                let units = Object.entries(trustData.units);
-                if (units.length === 0 && defaultUnits?.length) {
-                    units = defaultUnits.map(({ unit, quantity }) => [unit, quantity]);
-                } else if (units.length === 0) {
-                    units = [['--', 0]];
-                }
-                results.push({
-                    key: trustName,
-                    total: trustData.total,
-                    units: units
-                        .sort(([, a], [, b]) => b - a)
-                        .map(([unit, quantity]) => ({ unit, quantity })),
-                    isIndividual: true
-                });
-            });
-    }
-
-    return results;
-}
-
-function processAggregatedMode(aggregatedData, mode, period, latestDate, selectedProductCodes = null, regionsHierarchy = [], defaultUnits = null) {
-    const categoryMap = {
-        'region': 'regions',
-        'icb': 'icbs',
-        'national': 'national'
-    };
-
-    const categoryData = aggregatedData[categoryMap[mode]] || {};
-    const resultsMap = new Map();
-
-    Object.entries(categoryData).forEach(([name, info]) => {
-        if (!info?.products) return;
-
-        const totals = { total: 0, units: {} };
-
-        Object.entries(info.products).forEach(([productKey, product]) => {
-            if (selectedProductCodes && !selectedProductCodes.has(productKey)) {
-                return;
-            }
-
-            if (!product?.data) return;
-
-            const unit = product.unit || '';
-            const normalisedUnit = normaliseDDDUnit(unit);
-
-            Object.entries(product.data).forEach(([date, quantity]) => {
-                if (!shouldIncludeDate(date, period, latestDate)) return;
-
-                const parsedQuantity = parseFloat(quantity) || 0;
-                totals.total += parsedQuantity;
-
-                if (!totals.units[normalisedUnit]) {
-                    totals.units[normalisedUnit] = 0;
-                }
-                totals.units[normalisedUnit] += parsedQuantity;
-            });
-        });
-
-        let units = Object.entries(totals.units)
-            .sort(([, a], [, b]) => b - a)
-            .map(([unit, quantity]) => ({ unit, quantity }));
-        if (units.length === 0 && defaultUnits?.length) {
-            units = defaultUnits;
-        } else if (units.length === 0) {
-            units = [{ unit: '--', quantity: 0 }];
-        }
-        resultsMap.set(name, { key: name, total: totals.total, units });
-    });
-
-    const zeroUnits = defaultUnits?.length ? defaultUnits : [{ unit: '--', quantity: 0 }];
-    let allCategoryNames = [];
-    if (mode === 'region' && regionsHierarchy.length > 0) {
-        allCategoryNames = regionsHierarchy.map(r => r.region).filter(Boolean);
-    } else if (mode === 'icb' && regionsHierarchy.length > 0) {
-        allCategoryNames = regionsHierarchy.flatMap(r => (r.icbs || []).map(i => i.name)).filter(Boolean);
-    } else if (mode === 'national') {
-        allCategoryNames = ['National'];
-    }
-    allCategoryNames.forEach(name => {
-        if (!resultsMap.has(name)) {
-            resultsMap.set(name, { key: name, total: 0, units: zeroUnits });
-        }
-    });
-
-    return Array.from(resultsMap.values()).sort((a, b) => b.total - a.total);
-}
-
-function processRawDataMode(data, mode, period, latestDate, selectedOrganisations = [], months = []) {
-    if (!data?.length) return [];
-
-    const filteredData = data.map(item => filterItemDataByPeriod(item, period, latestDate, months));
-
-    const dataToProcess = selectedOrganisations.length > 0 
-        ? filteredData.filter(item => selectedOrganisations.includes(item.organisation__ods_name))
-        : filteredData;
-
-    const groupedData = {};
-
-    const singleUnitPerGroup = mode === 'product' || mode === 'unit';
-
-    dataToProcess.forEach(item => {
-        const groupKey = getGroupKey(item, mode);
-        
-        if (Array.isArray(groupKey)) {
-            groupKey.forEach(key => processItemForGroup(groupedData, key, item, months, period, latestDate, singleUnitPerGroup));
-        } else {
-            processItemForGroup(groupedData, groupKey, item, months, period, latestDate, singleUnitPerGroup);
-        }
-    });
-
-    return Object.entries(groupedData)
-        .map(([key, value]) => {
-            const units = value.unit != null
-                ? [{ unit: value.unit, quantity: value.total }]
-                : Object.entries(value.units || {})
-                    .sort(([, a], [, b]) => b - a)
-                    .map(([unit, quantity]) => ({ unit, quantity }));
-            return { key, total: value.total, units };
-        })
-        .sort((a, b) => b.total - a.total);
-}
-
-function getGroupKey(item, mode) {
-    switch (mode) {
-        case 'trust':
-            return item.organisation__ods_name || 'Unknown Organisation';
-        case 'product':
-            return item.vmp__name || 'Unknown Product';
-        case 'productGroup':
-            return item.vmp__vtm__name || 'Unknown Product Group';
-        case 'ingredient':
-            return item.ingredient_names?.length > 0 ? item.ingredient_names : ['Unknown Ingredient'];
-        case 'unit':
-            return item.unit ? [item.unit] : [];
-        default:
-            return item.vmp__name || 'Unknown';
-    }
-}
-
-function processItemForGroup(groupedData, groupKey, item, months = [], period, latestDate, singleUnitPerGroup = false) {
-    if (!groupedData[groupKey]) {
-        groupedData[groupKey] = singleUnitPerGroup
-            ? { total: 0, unit: '' }
-            : { total: 0, units: {} };
-    }
-
-    const g = groupedData[groupKey];
-    item.data?.forEach((value, i) => {
-        if (i >= months.length || !shouldIncludeDate(months[i], period, latestDate)) return;
-        const parsedQuantity = parseFloat(value) || 0;
-        g.total += parsedQuantity;
-
-        if (singleUnitPerGroup) {
-            if (!g.unit && item.unit) g.unit = normaliseDDDUnit(item.unit) || item.unit;
-        } else {
-            const normalisedUnit = normaliseDDDUnit(item.unit || '');
-            g.units[normalisedUnit] = (g.units[normalisedUnit] || 0) + parsedQuantity;
-        }
-    });
-}
-
-export function getModeDisplayName(mode) {
-    const modeNames = {
-        'trust': 'NHS Trust',
-        'region': 'Region',
-        'icb': 'ICB', 
-        'national': 'National total',
-        'product': 'Product',
-        'productGroup': 'Product group',
-        'ingredient': 'Ingredient',
-        'unit': 'Unit'
-    };
-    return modeNames[mode] || mode;
-}
-
-export function getChartExplainerText(mode, options = {}) {
-    const { hasSelectedOrganisations = false, currentModeHasData = true, vmpsCount = 0 } = options;
-
-    const baseExplainers = {
-        'trust': () => {
-            if (hasSelectedOrganisations) {
-                if (currentModeHasData) {
-                    return "This chart shows individual NHS Trust quantities over time for your selected trusts. Each line represents one trust, allowing you to compare their usage patterns.";
-                } else {
-                    return "This chart would show individual NHS Trust quantities, but the selected trusts have no data for these products.";
-                }
-            } else {
-                return "This chart shows individual NHS Trust quantities over time. Each line represents one trust, allowing you to compare usage patterns across different trusts.";
-            }
-        },
-
-        'icb': () => {
-            return "This chart shows quantities grouped by integrated care board (ICB) over time. Each line represents one ICB, combining data from all trusts within that area.";
-        },
-
-        'region': () => {
-            return "This chart shows quantities grouped by NHS region over time. Each line represents one region, combining data from all trusts within that area.";
-        },
-
-        'national': () => {
-            return "This chart shows the total national quantities over time, combining data from all NHS Trusts in England.";
-        },
-
-        'product': () => {
-            const trustContext = hasSelectedOrganisations ? 
-                "across the selected NHS Trusts" : 
-                "across all NHS Trusts";
-            
-            if (vmpsCount > 1) {
-                return `This chart compares quantities between different products over time. Each line represents one product, showing its total usage ${trustContext}.`;
-            } else {
-                return `This chart shows quantities for the selected product over time ${trustContext}.`;
-            }
-        },
-
-        'productGroup': () => {
-            const trustContext = hasSelectedOrganisations ? 
-                "within the selected NHS Trusts" : 
-                "across all NHS Trusts";
-            return `This chart shows quantities grouped by product category (VTM - Virtual Therapeutic Moiety) over time ${trustContext}. Each line represents a therapeutic group, combining all related products.`;
-        },
-
-        'ingredient': () => {
-            const trustContext = hasSelectedOrganisations ? 
-                "within the selected NHS Trusts" : 
-                "across all NHS Trusts";
-            return `This chart shows quantities grouped by active ingredient over time ${trustContext}. Each line represents one ingredient, combining the amount of that ingredient in the selected products.`;
-        },
-
-        'unit': () => {
-            const trustContext = hasSelectedOrganisations ? 
-                "within the selected NHS Trusts" : 
-                "across all NHS Trusts";
-            return `This chart shows quantities grouped by unit of measurement over time ${trustContext}. Each line represents one unit type (e.g., tablets, bottles, ampoules).`;
-        }
-    };
-
-    const explainerFunc = baseExplainers[mode];
-    if (explainerFunc) {
-        return explainerFunc();
-    }
-
-    return "This chart shows the selected data over time.";
-}
-
-export function getTableExplainerText(mode, options = {}) {
-    const { 
-        hasSelectedTrusts = false, 
-        selectedTrustsCount = 0,
-        selectedPeriod = 'all',
-        latestMonth = '',
-        latestYear = '',
-        dateRange = ''
-    } = options;
-
-    function getPeriodText() {
-        switch (selectedPeriod) {
-            case 'all':
-                return dateRange ? `across the period ${dateRange}` : 'across the entire period';
-            case 'latest_month':
-                return latestMonth ? `for ${latestMonth}` : 'for the latest month';
-            case 'latest_year':
-                return latestYear ? `for ${latestYear}` : 'for the latest year';
-            case 'current_fy':
-                if (latestMonth) {
-                    const latestDate = new Date(latestMonth);
-                    const fyStartYear = latestDate.getMonth() >= 3 ? 
-                        latestDate.getFullYear() : 
-                        latestDate.getFullYear() - 1;
-                    return `for the current financial year to date (April ${fyStartYear} - ${latestMonth})`;
-                }
-                return 'for the current financial year to date';
-            case 'last_12_months':
-                return 'for the last 12 months';
-            default:
-                return 'across the entire period';
-        }
-    }
-
-    const periodText = getPeriodText();
-
-    const baseExplainers = {
-        'trust': () => {
-            if (hasSelectedTrusts) {
-                return `This table shows the total quantities of the selected products issued by NHS trust ${periodText}. Data is grouped into "Selected trusts" (${selectedTrustsCount} trusts) and "All other trusts", allowing you to compare your selected NHS trusts against others.`;
-            } else {
-                return `This table shows the total quantities of the selected products issued by NHS trust ${periodText} for all trusts in England.`;
-            }
-        },
-
-        'region': () => {
-            return `This table shows the total quantities of the selected products issued in all NHS trusts in England by NHS region ${periodText}.`;
-        },
-
-        'icb': () => {
-            return `This table shows the total quantities of the selected products issued in all NHS trusts in England by integrated care board (ICB) ${periodText}.`;
-        },
-
-        'national': () => {
-            return `This table shows the total national quantity of the selected products issued in all NHS trusts in England ${periodText}.`;
-        },
-
-        'product': () => {
-            if (hasSelectedTrusts) {
-                return `This table shows the total quantities of each of the selected products issued ${periodText}, filtered to only include data from your ${selectedTrustsCount} selected NHS trusts.`;
-            } else {
-                return `This table shows the total quantities of each of the selected products issued ${periodText}, in all NHS trusts in England.`;
-            }
-        },
-
-        'productGroup': () => {
-            if (hasSelectedTrusts) {
-                return `This table shows the total quantities of the selected products issued by product group ${periodText}, filtered to only include data from your ${selectedTrustsCount} selected NHS trusts.`;
-            } else {
-                return `This table shows the total quantities of the selected products issued by product group ${periodText} for all NHS trusts in England.`;
-            }
-        },
-
-        'ingredient': () => {
-            if (hasSelectedTrusts) {
-                return `This table shows total quantities by active ingredient ${periodText}, filtered to only include data from your ${selectedTrustsCount} selected trusts.`;
-            } else {
-                return `This table shows total quantities by active ingredient ${periodText} for all trusts in England.`;
-            }
-        },
-
-        'unit': () => {
-            if (hasSelectedTrusts) {
-                return `This table shows total quantities by unit of measurement ${periodText}, filtered to only include data from your ${selectedTrustsCount} selected trusts.`;
-            } else {
-                return `This table shows total quantities by unit of measurement ${periodText} for all trusts in England.`;
-            }
-        }
-    };
-
-    const explainerFunc = baseExplainers[mode];
-    if (explainerFunc) {
-        return explainerFunc();
-    }
-
-    return `This table shows the total quantities of the selected products issued ${periodText}.`;
 }
 
 export function calculatePercentiles(data, allTrusts = [], months = []) {
@@ -1371,23 +1067,131 @@ export function getTrustCount(percentilesResult) {
     return percentilesResult.trustCount;
 }
 
-export const MODE_MAPPINGS = {
-    trust: 'trust',
-    region: 'region',
-    icb: 'icb',
-    national: 'national',
-    product: 'product',
-    productgroup: 'productGroup',
-    product_group: 'productGroup',
-    unit: 'unit',
-    ingredient: 'ingredient'
-};
 
-export function normaliseMode(mode) {
-    if (!mode || typeof mode !== 'string') return null;
-    const trimmed = mode.trim();
-    if (!trimmed) return null;
-    const lower = trimmed.toLowerCase();
-    const normalised = lower.replace(/[-\s]/g, '_');
-    return MODE_MAPPINGS[normalised] || MODE_MAPPINGS[lower] || null;
+export class ViewModeCalculator {
+    constructor(resultsStore, analyseOptions, organisationSearchStore, vmps, scope = ANALYSIS_SCOPE.ALL) {
+        this.resultsStore = resultsStore;
+        this.analyseOptions = analyseOptions;
+        this.organisationSearchStore = organisationSearchStore;
+        this.vmps = vmps;
+        this.scope = scope;
+    }
+
+    calculateAvailableModes() {
+        const modes = [];
+        
+        // Only add modes if there are VMPs with valid data
+        if (this.vmps && this.vmps.length > 0) {
+            if (this.scope === ANALYSIS_SCOPE.NATIONAL) {
+                modes.push({ value: 'national', label: getNationalModeLabel(this.scope) });
+                modes.push(...this.getProductModes());
+                return modes;
+            }
+
+            modes.push({ value: 'trust', label: 'NHS Trust' });
+            
+            modes.push(...this.getAggregationModes());
+            
+            modes.push(...this.getProductModes());
+        }
+        
+        return modes;
+    }
+
+    hasSelectedOrganisations() {
+        return this.analyseOptions.selectedOrganisations && 
+               this.analyseOptions.selectedOrganisations.length > 0;
+    }
+
+    hasSelectedOrganisationsWithData() {
+        if (!this.hasSelectedOrganisations()) return false;
+
+        const selectedOrgNames = new Set(this.analyseOptions.selectedOrganisations);
+
+        const selectedOrganisationsWithData = this.resultsStore.analysisData
+            ?.filter(item => {
+                const orgName = item.organisation__ods_name;
+                const isSelected = selectedOrgNames.has(orgName);
+                const hasData = item.data && Array.isArray(item.data) &&
+                    item.data.some(v => v > 0 && !isNaN(parseFloat(v)));
+                return isSelected && hasData;
+            }) || [];
+
+        return selectedOrganisationsWithData.length >= 1;
+    }
+
+    getAggregationModes() {
+        const modes = [];
+
+        if (!this.resultsStore.aggregatedData) return modes;
+        
+        const { regions = {}, icbs = {}, national = {} } = this.resultsStore.aggregatedData;
+        
+        if (icbs && Object.keys(icbs).length > 1) {
+            modes.push({ value: 'icb', label: 'ICB' });
+        }
+        
+        if (regions && Object.keys(regions).length > 1) {
+            modes.push({ value: 'region', label: 'Region' });
+        }
+        
+        if (
+            this.scope !== ANALYSIS_SCOPE.TRUST &&
+            national &&
+            Object.keys(national).length > 0
+        ) {
+            modes.push({ value: 'national', label: getNationalModeLabel(this.scope) });
+        }
+
+        if (this.resultsStore.analysisData) {
+            const mappedICBs = new Set(
+                this.resultsStore.analysisData.map(item => item.organisation__icb).filter(Boolean)
+            );
+
+            if (mappedICBs.size > 1 && !modes.some(m => m.value === 'icb')) {
+                modes.push({ value: 'icb', label: 'ICB' });
+            }
+
+            const uniqueRegions = new Set(this.resultsStore.analysisData.map(item => item.organisation__region).filter(Boolean));
+            if (uniqueRegions.size > 1 && !modes.some(m => m.value === 'region')) {
+                modes.push({ value: 'region', label: 'Region' });
+            }
+        }
+        
+        return modes;
+    }
+
+    getProductModes() {
+        const modes = [];
+        
+        if (!this.vmps || this.vmps.length === 0) return modes;
+
+        if (this.vmps.length > 1) {
+            modes.push({ value: 'product', label: 'Product' });
+        }
+
+        const uniqueVtms = new Set(this.vmps.map(vmp => vmp.vtm).filter(vtm => vtm && vtm !== '-' && vtm !== 'nan'));
+        if (uniqueVtms.size > 1) {
+            modes.push({ value: 'productGroup', label: 'Product Group' });
+        }
+
+        const uniqueIngredients = new Set(
+            this.vmps.flatMap(vmp => (vmp.ingredients || []))
+                .filter(ing => ing && ing !== '-' && ing !== 'nan')
+        );
+        if (uniqueIngredients.size > 1) {
+            modes.push({ value: 'ingredient', label: 'Ingredient' });
+        }
+
+        const uniqueUnits = new Set(
+            this.vmps.flatMap(vmp => Array.from(vmp.units || []))
+                .filter(unit => unit && unit !== '-' && unit !== 'nan')
+                .map(unit => normaliseDDDUnit(unit))
+        );
+        if (uniqueUnits.size > 1) {
+            modes.push({ value: 'unit', label: 'Unit' });
+        }
+
+        return modes;
+    }
 }

--- a/src/components/analyse/lib/analyseData.js
+++ b/src/components/analyse/lib/analyseData.js
@@ -1069,12 +1069,13 @@ export function getTrustCount(percentilesResult) {
 
 
 export class ViewModeCalculator {
-    constructor(resultsStore, analyseOptions, organisationSearchStore, vmps, scope = ANALYSIS_SCOPE.ALL) {
+    constructor(resultsStore, analyseOptions, organisationSearchStore, vmps, scope = ANALYSIS_SCOPE.ALL, isAuthenticated = false) {
         this.resultsStore = resultsStore;
         this.analyseOptions = analyseOptions;
         this.organisationSearchStore = organisationSearchStore;
         this.vmps = vmps;
         this.scope = scope;
+        this.isAuthenticated = isAuthenticated;
     }
 
     calculateAvailableModes() {
@@ -1122,6 +1123,10 @@ export class ViewModeCalculator {
 
     getAggregationModes() {
         const modes = [];
+
+        if (!this.isAuthenticated && this.hasSelectedOrganisations()) {
+            return modes;
+        }
 
         if (!this.resultsStore.aggregatedData) return modes;
         

--- a/src/components/analyse/lib/analyseUrlParams.js
+++ b/src/components/analyse/lib/analyseUrlParams.js
@@ -1,0 +1,450 @@
+import {
+    encodeTrustTypeForUrl,
+    normaliseScopeFilters,
+} from '../../../utils/scopeFilters.js';
+import { formatArrayParam, parseArrayParam, setUrlParams } from '../../../utils/utils.js';
+import {
+    ANALYSIS_SCOPE,
+    isAggregationChartMode,
+    normaliseMode,
+    normaliseScope,
+} from './analysisScope.js';
+import {
+    allOverlaySelection,
+    encodeChartOverlayParam,
+    parseChartOverlayParam,
+} from './chartOverlay.js';
+
+export const PRODUCT_PARAM_BY_TYPE = {
+    vmp: 'vmps',
+    vtm: 'vtms',
+    ingredient: 'ingredients',
+    atc: 'atcs',
+};
+
+export const PRODUCT_TYPE_ORDER = Object.keys(PRODUCT_PARAM_BY_TYPE);
+
+export const ANALYSIS_TRUSTS_PARAM = 'trusts';
+export const ANALYSIS_SCOPE_PARAM = 'scope';
+export const ANALYSIS_TRUST_TYPES_PARAM = 'trust_types';
+export const ANALYSIS_REGIONS_PARAM = 'regions';
+export const ANALYSIS_ICBS_PARAM = 'icbs';
+export const ANALYSIS_CHART_REGIONS_PARAM = 'chart_regions';
+export const ANALYSIS_CHART_ICBS_PARAM = 'chart_icbs';
+export const ANALYSIS_CANCER_ALLIANCES_PARAM = 'cancer_alliances';
+export const ANALYSIS_SHELFORD_PARAM = 'shelford';
+export const ANALYSIS_QUANTITY_PARAM = 'quantity';
+export const ANALYSIS_MODE_PARAM = 'mode';
+export const ANALYSIS_PERCENTILES_PARAM = 'show_percentiles';
+export const ANALYSIS_EXCLUDED_VMPS_PARAM = 'excluded_vmps';
+
+export const QUANTITY_TYPE_CODES = {
+    'SCMD Quantity': 'scmd',
+    'Unit Dose Quantity': 'dose',
+    'Ingredient Quantity': 'ingredient',
+    'Defined Daily Dose Quantity': 'ddd',
+};
+
+export const SUPPORTED_ANALYSIS_PARAMS = [
+    ...Object.values(PRODUCT_PARAM_BY_TYPE),
+    ANALYSIS_TRUSTS_PARAM,
+    ANALYSIS_SCOPE_PARAM,
+    ANALYSIS_TRUST_TYPES_PARAM,
+    ANALYSIS_REGIONS_PARAM,
+    ANALYSIS_ICBS_PARAM,
+    ANALYSIS_CHART_REGIONS_PARAM,
+    ANALYSIS_CHART_ICBS_PARAM,
+    ANALYSIS_CANCER_ALLIANCES_PARAM,
+    ANALYSIS_SHELFORD_PARAM,
+    ANALYSIS_QUANTITY_PARAM,
+    ANALYSIS_MODE_PARAM,
+    ANALYSIS_PERCENTILES_PARAM,
+    ANALYSIS_EXCLUDED_VMPS_PARAM,
+];
+
+export function encodeQuantityType(quantityType) {
+    if (!quantityType) return null;
+    const trimmed = quantityType.trim();
+    return QUANTITY_TYPE_CODES[trimmed] || null;
+}
+
+export function getShowPercentilesParam(mode, trusts, showPercentilesValue, scope = 'all') {
+    if (scope === ANALYSIS_SCOPE.TRUST || mode !== 'trust') return null;
+    const hasTrusts = Array.isArray(trusts) && trusts.length > 0;
+    if (hasTrusts && showPercentilesValue === true) return 'true';
+    return null;
+}
+
+export function getRegionCodeMaps(hierarchy = []) {
+    const regions = hierarchy || [];
+    const regionCodeByName = new Map(
+        regions
+            .filter(region => region?.region && region?.region_code)
+            .map(region => [region.region, region.region_code])
+    );
+    const regionNameByCode = new Map(
+        regions
+            .filter(region => region?.region && region?.region_code)
+            .map(region => [region.region_code, region.region])
+    );
+    const icbCodeByName = new Map(
+        regions
+            .flatMap(region => region?.icbs || [])
+            .filter(icb => icb?.name && icb?.code)
+            .map(icb => [icb.name, icb.code])
+    );
+    const icbNameByCode = new Map(
+        regions
+            .flatMap(region => region?.icbs || [])
+            .filter(icb => icb?.name && icb?.code)
+            .map(icb => [icb.code, icb.name])
+    );
+    return { regionCodeByName, regionNameByCode, icbCodeByName, icbNameByCode };
+}
+
+export function getCancerAllianceCodeMaps(cancerAlliances = []) {
+    const codeByName = new Map();
+    const nameByCode = new Map();
+    (cancerAlliances || []).forEach((alliance) => {
+        const name = alliance?.name;
+        const code = alliance?.code;
+        if (!name || !code) return;
+        codeByName.set(name, code);
+        nameByCode.set(code, name);
+    });
+    return { codeByName, nameByCode };
+}
+
+export function encodeCancerAllianceForUrl(name, codeByName = new Map()) {
+    if (!name) return name;
+    return codeByName.get(name) || name;
+}
+
+export function decodeCancerAllianceFromUrl(value, nameByCode = new Map()) {
+    if (!value) return value;
+    const trimmed = String(value).trim();
+    return nameByCode.get(trimmed) || trimmed;
+}
+
+export function buildAnalysisUrlParams({
+    products = [],
+    trusts = [],
+    quantityType = null,
+    scope = 'all',
+    scopeFilters = {},
+    mode = null,
+    showPercentiles = null,
+    excludedVmps = [],
+    chartRegions = null,
+    chartIcbs = null,
+    getOrgCode,
+    regionCodeByName = new Map(),
+    icbCodeByName = new Map(),
+    cancerAllianceCodeByName = new Map(),
+} = {}) {
+    const params = {};
+
+    const productGroups = {};
+    products.forEach(item => {
+        if (!item?.code || !item?.type) return;
+        const typeKey = item.type.toLowerCase();
+        const paramName = PRODUCT_PARAM_BY_TYPE[typeKey];
+        if (!paramName) return;
+
+        if (!productGroups[paramName]) productGroups[paramName] = [];
+        if (!productGroups[paramName].includes(item.code)) {
+            productGroups[paramName].push(item.code);
+        }
+    });
+
+    Object.entries(productGroups).forEach(([paramName, codes]) => {
+        if (codes.length > 0) {
+            params[paramName] = formatArrayParam(codes);
+        }
+    });
+
+    const trustCodes = (trusts || []).map(name => getOrgCode?.(name)).filter(Boolean);
+    if (trustCodes.length > 0) {
+        params[ANALYSIS_TRUSTS_PARAM] = formatArrayParam(trustCodes);
+    }
+
+    const normalisedScope = normaliseScope(scope);
+    if (normalisedScope !== 'all') {
+        params[ANALYSIS_SCOPE_PARAM] = normalisedScope;
+    }
+
+    if (normalisedScope === ANALYSIS_SCOPE.GROUP) {
+        const setScopeFilterParam = (paramName, values, encode = value => value) => {
+            const encoded = Array.isArray(values)
+                ? Array.from(new Set(values.map(String).filter(Boolean).map(encode).filter(Boolean))).sort()
+                : [];
+            if (encoded.length > 0) {
+                params[paramName] = formatArrayParam(encoded);
+            }
+        };
+
+        setScopeFilterParam(ANALYSIS_TRUST_TYPES_PARAM, scopeFilters?.trustTypes, encodeTrustTypeForUrl);
+        setScopeFilterParam(ANALYSIS_REGIONS_PARAM, scopeFilters?.regions, name => regionCodeByName.get(name) || name);
+        setScopeFilterParam(ANALYSIS_ICBS_PARAM, scopeFilters?.icbs, name => icbCodeByName.get(name) || name);
+        setScopeFilterParam(
+            ANALYSIS_CANCER_ALLIANCES_PARAM,
+            scopeFilters?.cancerAlliances,
+            name => encodeCancerAllianceForUrl(name, cancerAllianceCodeByName)
+        );
+
+        if (scopeFilters?.shelford === 'in' || scopeFilters?.shelford === 'not_in') {
+            params[ANALYSIS_SHELFORD_PARAM] = scopeFilters.shelford;
+        }
+    }
+
+    if (quantityType) {
+        const encodedQuantity = encodeQuantityType(quantityType);
+        if (encodedQuantity) {
+            params[ANALYSIS_QUANTITY_PARAM] = encodedQuantity;
+        }
+    }
+
+    if (mode) {
+        const normalisedMode = normaliseMode(mode);
+        const shouldForceModeParam = showPercentiles === 'true';
+        if (normalisedMode && (normalisedMode !== 'trust' || shouldForceModeParam)) {
+            params[ANALYSIS_MODE_PARAM] = normalisedMode;
+        }
+    }
+
+    if (showPercentiles !== null) {
+        params[ANALYSIS_PERCENTILES_PARAM] = showPercentiles;
+    }
+
+    if ((excludedVmps || []).length > 0) {
+        params[ANALYSIS_EXCLUDED_VMPS_PARAM] = formatArrayParam(excludedVmps);
+    }
+
+    const encodedChartRegions = encodeChartOverlayParam(chartRegions, regionCodeByName);
+    if (encodedChartRegions) {
+        params[ANALYSIS_CHART_REGIONS_PARAM] = encodedChartRegions;
+    }
+
+    const encodedChartIcbs = encodeChartOverlayParam(chartIcbs, icbCodeByName);
+    if (encodedChartIcbs) {
+        params[ANALYSIS_CHART_ICBS_PARAM] = encodedChartIcbs;
+    }
+
+    return params;
+}
+
+export function updateAnalysisUrl(urlState, setParams = setUrlParams) {
+    if (typeof window === 'undefined') return;
+    const params = buildAnalysisUrlParams(urlState);
+    setParams(params, SUPPORTED_ANALYSIS_PARAMS);
+}
+
+export function buildValidationParams(urlParams, showPercentiles = null) {
+    const queryParams = new URLSearchParams();
+
+    PRODUCT_TYPE_ORDER.forEach(type => {
+        const paramName = PRODUCT_PARAM_BY_TYPE[type];
+        const paramValue = urlParams.get(paramName);
+        if (paramValue?.trim()) {
+            queryParams.append(paramName, paramValue);
+        }
+    });
+
+    [ANALYSIS_TRUSTS_PARAM, ANALYSIS_QUANTITY_PARAM, ANALYSIS_MODE_PARAM,
+        ANALYSIS_EXCLUDED_VMPS_PARAM].forEach(param => {
+        const value = urlParams.get(param);
+        if (value?.trim()) {
+            queryParams.append(param, value.trim());
+        }
+    });
+
+    if (showPercentiles?.trim()) {
+        queryParams.append(ANALYSIS_PERCENTILES_PARAM, showPercentiles.trim());
+    }
+
+    return queryParams;
+}
+
+export function parseScopeFiltersFromUrl(urlParams, {
+    regionNameByCode = new Map(),
+    icbNameByCode = new Map(),
+    cancerAllianceNameByCode = new Map(),
+    decodeTrustTypeFromUrl = value => value,
+} = {}) {
+    const trustTypes = parseArrayParam(urlParams.get(ANALYSIS_TRUST_TYPES_PARAM)).map(decodeTrustTypeFromUrl);
+    const regions = parseArrayParam(urlParams.get(ANALYSIS_REGIONS_PARAM)).map(value => regionNameByCode.get(value) || value);
+    const icbs = parseArrayParam(urlParams.get(ANALYSIS_ICBS_PARAM)).map(value => icbNameByCode.get(value) || value);
+    const cancerAlliances = parseArrayParam(urlParams.get(ANALYSIS_CANCER_ALLIANCES_PARAM)).map(
+        value => decodeCancerAllianceFromUrl(value, cancerAllianceNameByCode)
+    );
+    const shelfordParam = (urlParams.get(ANALYSIS_SHELFORD_PARAM) || '').trim().toLowerCase();
+    const shelford = shelfordParam === 'in' || shelfordParam === 'not_in' ? shelfordParam : null;
+
+    return normaliseScopeFilters({
+        trustTypes,
+        regions,
+        icbs,
+        cancerAlliances,
+        shelford,
+    });
+}
+
+export function planAnalysisHydrate({
+    urlParams,
+    regionsHierarchy = [],
+    cancerAlliances = [],
+    decodeTrustTypeFromUrl = value => value,
+} = {}) {
+    const scope = normaliseScope(urlParams.get(ANALYSIS_SCOPE_PARAM));
+    const mode = normaliseMode(urlParams.get(ANALYSIS_MODE_PARAM));
+    const hasExplicitTrustSelection = parseArrayParam(urlParams.get(ANALYSIS_TRUSTS_PARAM)).length > 0;
+    const { regionNameByCode, icbNameByCode } = getRegionCodeMaps(regionsHierarchy);
+    const { nameByCode: cancerAllianceNameByCode } = getCancerAllianceCodeMaps(cancerAlliances);
+
+    const scopeFilters = parseScopeFiltersFromUrl(urlParams, {
+        regionNameByCode,
+        icbNameByCode,
+        cancerAllianceNameByCode,
+        decodeTrustTypeFromUrl,
+    });
+
+    const rawShowPercentiles = urlParams.get(ANALYSIS_PERCENTILES_PARAM);
+    const showPercentilesRaw =
+        scope === ANALYSIS_SCOPE.TRUST ||
+        (rawShowPercentiles?.toLowerCase() === 'true' && mode !== 'trust')
+            ? null
+            : rawShowPercentiles;
+
+    return {
+        scope,
+        scopeFilters,
+        mode,
+        showPercentilesRaw,
+        chartRegions: mode === 'region'
+            ? parseChartOverlayParam(urlParams.get(ANALYSIS_CHART_REGIONS_PARAM), regionNameByCode)
+            : allOverlaySelection(),
+        chartIcbs: mode === 'icb'
+            ? parseChartOverlayParam(urlParams.get(ANALYSIS_CHART_ICBS_PARAM), icbNameByCode)
+            : allOverlaySelection(),
+        hasExplicitTrustSelection,
+        validationQuery: buildValidationParams(urlParams, showPercentilesRaw),
+        shouldShowAdvancedOptions: scope !== ANALYSIS_SCOPE.ALL,
+    };
+}
+
+export function planValidationStorePatch({
+    data,
+    scope = ANALYSIS_SCOPE.ALL,
+    mode = null,
+    showPercentilesRaw = null,
+    hasExplicitTrustSelection = false,
+} = {}) {
+    const hydratedTrustNames = Array.isArray(data?.valid_trusts)
+        ? data.valid_trusts.map(trust => trust.ods_name).filter(Boolean)
+        : [];
+
+    const stashTrustsForAggregation =
+        scope !== ANALYSIS_SCOPE.TRUST &&
+        hasExplicitTrustSelection &&
+        isAggregationChartMode(mode);
+
+    const selectedOrganisations = scope === ANALYSIS_SCOPE.TRUST
+        ? hydratedTrustNames.slice(0, 1)
+        : (hasExplicitTrustSelection && !stashTrustsForAggregation ? hydratedTrustNames : []);
+
+    const rememberedOverlayOrganisations = stashTrustsForAggregation
+        ? hydratedTrustNames
+        : (scope !== ANALYSIS_SCOPE.TRUST && hasExplicitTrustSelection ? hydratedTrustNames : []);
+
+    const organisationSelection = scope === ANALYSIS_SCOPE.TRUST ? selectedOrganisations : [];
+    const hasValidTrusts = selectedOrganisations.length > 0;
+    const excludedVmps = Array.isArray(data?.excluded_vmps)
+        ? Array.from(new Set(data.excluded_vmps.map(String).filter(Boolean))).sort()
+        : [];
+
+    let showPercentiles;
+    if (showPercentilesRaw === 'true') {
+        showPercentiles = true;
+    } else if (showPercentilesRaw === 'false') {
+        showPercentiles = false;
+    } else if (data?.mode === 'trust' && hasValidTrusts) {
+        showPercentiles = data.show_percentiles ?? false;
+    } else {
+        showPercentiles = !hasValidTrusts;
+    }
+
+    return {
+        selectedVMPs: Array.isArray(data?.valid_products) ? data.valid_products : null,
+        quantityType: data?.quantity_type || null,
+        selectedOrganisations,
+        rememberedOverlayOrganisations,
+        organisationSelection,
+        showPercentiles,
+        excludedVmps,
+        mode: mode || null,
+    };
+}
+
+export function applyHydrateStorePatch(patch, {
+    analyseOptions,
+    organisationSearchStore,
+    resultsStore,
+    modeSelectorStore,
+} = {}) {
+    if (!patch) return;
+
+    if (patch.selectedVMPs?.length > 0) {
+        analyseOptions.update(options => ({
+            ...options,
+            selectedVMPs: patch.selectedVMPs,
+        }));
+    }
+
+    organisationSearchStore.updateSelection(patch.organisationSelection);
+    analyseOptions.setSelectedOrganisations(patch.selectedOrganisations);
+    analyseOptions.setRememberedOverlayOrganisations(patch.rememberedOverlayOrganisations);
+    resultsStore.update(store => ({
+        ...store,
+        showPercentiles: patch.showPercentiles,
+        excludedVmps: patch.excludedVmps,
+    }));
+
+    if (patch.mode) {
+        modeSelectorStore.setSelectedMode(patch.mode);
+    }
+}
+
+export async function finishValidatedHydrate({
+    patch,
+    selectedScope,
+    selectedScopeFilters,
+    analyseOptions,
+    organisationSearchStore,
+    resultsStore,
+    modeSelectorStore,
+    applyQuantityType,
+    cleanupUrlParams,
+    waitForUi,
+} = {}) {
+    applyHydrateStorePatch(patch, {
+        analyseOptions,
+        organisationSearchStore,
+        resultsStore,
+        modeSelectorStore,
+    });
+
+    if (patch.selectedVMPs?.length > 0) {
+        await applyQuantityType?.(patch);
+    }
+
+    cleanupUrlParams?.();
+    await waitForUi?.();
+
+    if (selectedScope === ANALYSIS_SCOPE.GROUP) {
+        organisationSearchStore.applyScopeFilters(selectedScopeFilters);
+    }
+
+    return {
+        excludedVmps: patch.excludedVmps || [],
+    };
+}

--- a/src/components/analyse/lib/analysisScope.js
+++ b/src/components/analyse/lib/analysisScope.js
@@ -1,11 +1,40 @@
+import { cancerAllianceDisplayName } from '../../../utils/scopeFilters.js';
+
 export const ANALYSIS_SCOPE = {
     ALL: 'all',
     NATIONAL: 'national',
-    SINGLE: 'single',
-    FILTERED: 'filtered',
+    TRUST: 'trust',
+    GROUP: 'group',
 };
 
 export const SCOPE_OPTIONS = Object.values(ANALYSIS_SCOPE);
+
+export const MODE_MAPPINGS = {
+    trust: 'trust',
+    region: 'region',
+    icb: 'icb',
+    national: 'national',
+    product: 'product',
+    productgroup: 'productGroup',
+    product_group: 'productGroup',
+    unit: 'unit',
+    ingredient: 'ingredient',
+};
+
+export const AGGREGATION_CHART_MODES = ['national', 'icb', 'region'];
+
+export function isAggregationChartMode(mode) {
+    return AGGREGATION_CHART_MODES.includes(mode);
+}
+
+export function normaliseMode(mode) {
+    if (!mode || typeof mode !== 'string') return null;
+    const trimmed = mode.trim();
+    if (!trimmed) return null;
+    const lower = trimmed.toLowerCase();
+    const normalised = lower.replace(/[-\s]/g, '_');
+    return MODE_MAPPINGS[normalised] || MODE_MAPPINGS[lower] || null;
+}
 
 export const TRUST_PERCENTILE_MIN_COUNT = 30;
 export const TRUST_OVERLAY_MAX_COUNT = 30;
@@ -23,10 +52,10 @@ export function resolveAnalysisCohort(scope, {
 } = {}) {
     const normalisedScope = normaliseScope(scope);
 
-    if (normalisedScope === ANALYSIS_SCOPE.FILTERED) {
+    if (normalisedScope === ANALYSIS_SCOPE.GROUP) {
         return Array.from(availableItems || []);
     }
-    if (normalisedScope === ANALYSIS_SCOPE.SINGLE) {
+    if (normalisedScope === ANALYSIS_SCOPE.TRUST) {
         return (selectedItems || []).slice(0, 1);
     }
     if (normalisedScope === ANALYSIS_SCOPE.NATIONAL) {
@@ -45,11 +74,11 @@ export function getScopedTrustCodes(scope, selectedTrustNames = [], {
         .map(name => getOrgCode?.(name))
         .filter(Boolean);
 
-    if (normalisedScope === ANALYSIS_SCOPE.SINGLE) {
+    if (normalisedScope === ANALYSIS_SCOPE.TRUST) {
         return selectedTrustCodes;
     }
 
-    if (normalisedScope === ANALYSIS_SCOPE.FILTERED) {
+    if (normalisedScope === ANALYSIS_SCOPE.GROUP) {
         return Array.from(new Set(
             Array.from(availableItems || [])
                 .map(name => getOrgCode?.(name))
@@ -65,7 +94,7 @@ export function resolveNextOverlaySelection(scope, {
     overlayOrganisations,
 } = {}) {
     const normalisedScope = normaliseScope(scope);
-    if (normalisedScope === ANALYSIS_SCOPE.SINGLE) {
+    if (normalisedScope === ANALYSIS_SCOPE.TRUST) {
         return (selectedItems || []).slice(0, 1);
     }
     if (Array.isArray(overlayOrganisations)) {
@@ -75,7 +104,7 @@ export function resolveNextOverlaySelection(scope, {
 }
 
 export function isNarrowedAnalysisScope(scope) {
-    return scope === ANALYSIS_SCOPE.SINGLE || scope === ANALYSIS_SCOPE.FILTERED;
+    return scope === ANALYSIS_SCOPE.TRUST || scope === ANALYSIS_SCOPE.GROUP;
 }
 
 export function getNationalModeLabel(scope, { longForm = false } = {}) {
@@ -99,8 +128,8 @@ export function buildAnalysisRequestPayload({
 
 export function arePercentilesDisabled(scope, trustCount = 0) {
     const normalisedScope = normaliseScope(scope);
-    return normalisedScope === ANALYSIS_SCOPE.SINGLE
-        || (normalisedScope === ANALYSIS_SCOPE.FILTERED && trustCount < TRUST_PERCENTILE_MIN_COUNT);
+    return normalisedScope === ANALYSIS_SCOPE.TRUST
+        || (normalisedScope === ANALYSIS_SCOPE.GROUP && trustCount < TRUST_PERCENTILE_MIN_COUNT);
 }
 
 export function computePercentileScopeConstraints({
@@ -132,4 +161,425 @@ export function computePercentileScopeConstraints({
     }
 
     return patches;
+}
+
+export function getModeDisplayName(mode, scope = ANALYSIS_SCOPE.ALL) {
+    if (mode === 'national') {
+        return getNationalModeLabel(scope);
+    }
+    const modeNames = {
+        'trust': 'NHS Trust',
+        'region': 'Region',
+        'icb': 'ICB',
+        'product': 'Product',
+        'productGroup': 'Product group',
+        'ingredient': 'Ingredient',
+        'unit': 'Unit'
+    };
+    return modeNames[mode] || mode;
+}
+
+export function formatInScopePopulationPhrase({
+    trustCount = null,
+    filterDescription = '',
+    includeArticle = true
+} = {}) {
+    const hasCount = Number.isFinite(trustCount) && trustCount > 0;
+    const trustNoun = hasCount
+        ? (trustCount === 1 ? '1 trust' : `${trustCount} trusts`)
+        : 'trusts';
+    const article = includeArticle && hasCount ? 'the ' : '';
+    const filterSuffix = filterDescription ? ` (${filterDescription})` : '';
+    return `${article}${trustNoun} in the scope for this analysis${filterSuffix}`;
+}
+
+function getDefaultTrustPopulationPhrase(scope, scopeDetails = {}) {
+    if (scope === ANALYSIS_SCOPE.GROUP) {
+        return formatInScopePopulationPhrase({
+            trustCount: scopeDetails.trustCount,
+            filterDescription: scopeDetails.filterDescription,
+            includeArticle: false
+        });
+    }
+    if (scope === ANALYSIS_SCOPE.TRUST) {
+        return 'the selected NHS Trust';
+    }
+    return 'all NHS Trusts in England';
+}
+
+function getChartTrustContext(scope, {
+    hasSelectedOrganisations,
+    selectedTrustLabel,
+    preposition = 'across',
+    trustCount = null,
+    filterDescription = ''
+} = {}) {
+    if (hasSelectedOrganisations) {
+        return `${preposition} the ${selectedTrustLabel}`;
+    }
+    if (scope === ANALYSIS_SCOPE.NATIONAL) {
+        return 'nationally';
+    }
+    if (scope === ANALYSIS_SCOPE.GROUP) {
+        return `${preposition} ${formatInScopePopulationPhrase({ trustCount, filterDescription })}`;
+    }
+    if (scope === ANALYSIS_SCOPE.TRUST) {
+        return `${preposition} the selected NHS Trust`;
+    }
+    return `${preposition} all NHS Trusts`;
+}
+
+function createScopeCopyContext({
+    scope = ANALYSIS_SCOPE.ALL,
+    inScopeTrustCount = null,
+    scopeFilterDescription = '',
+    hasSelectedOrganisations = false,
+    selectedOrganisationsCount = 0,
+} = {}) {
+    const scopeDetails = {
+        trustCount: inScopeTrustCount,
+        filterDescription: scopeFilterDescription,
+    };
+    const inScopePopulation = formatInScopePopulationPhrase({
+        trustCount: inScopeTrustCount,
+        filterDescription: scopeFilterDescription,
+    });
+    const defaultPopulation = getDefaultTrustPopulationPhrase(scope, scopeDetails);
+    const singleSelectedTrust = hasSelectedOrganisations && selectedOrganisationsCount === 1;
+    const selectedTrustLabel = singleSelectedTrust ? 'selected NHS Trust' : 'selected NHS Trusts';
+    const selectedTrustsPhrase = singleSelectedTrust
+        ? 'your selected NHS Trust'
+        : `your ${selectedOrganisationsCount} selected NHS Trusts`;
+    const otherTrustsLabel = scope === ANALYSIS_SCOPE.GROUP
+        ? 'All other in-scope trusts'
+        : 'All other trusts';
+    const productTrustContext = getChartTrustContext(scope, {
+        hasSelectedOrganisations,
+        selectedTrustLabel,
+        preposition: 'across',
+        ...scopeDetails,
+    });
+    const groupedTrustContext = getChartTrustContext(scope, {
+        hasSelectedOrganisations,
+        selectedTrustLabel,
+        preposition: hasSelectedOrganisations ? 'within' : 'across',
+        ...scopeDetails,
+    });
+
+    return {
+        scope,
+        scopeDetails,
+        inScopePopulation,
+        defaultPopulation,
+        singleSelectedTrust,
+        selectedTrustLabel,
+        selectedTrustsPhrase,
+        otherTrustsLabel,
+        productTrustContext,
+        groupedTrustContext,
+    };
+}
+
+function formatListForSentence(items) {
+    if (items.length === 1) return items[0];
+    if (items.length === 2) return `${items[0]} and ${items[1]}`;
+    return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+}
+
+export function formatScopeFilterDescription(scopeFilters = {}) {
+    const parts = [];
+    const trustTypes = Array.isArray(scopeFilters.trustTypes)
+        ? scopeFilters.trustTypes.map(String).filter(Boolean)
+        : [];
+    const regions = Array.isArray(scopeFilters.regions)
+        ? scopeFilters.regions.map(String).filter(Boolean)
+        : [];
+    const icbs = Array.isArray(scopeFilters.icbs)
+        ? scopeFilters.icbs.map(String).filter(Boolean)
+        : [];
+    const cancerAlliances = Array.isArray(scopeFilters.cancerAlliances)
+        ? scopeFilters.cancerAlliances.map(String).filter(Boolean).map(cancerAllianceDisplayName)
+        : [];
+
+    if (trustTypes.length === 1) {
+        parts.push(`${trustTypes[0]} trusts`);
+    } else if (trustTypes.length > 1) {
+        parts.push(`trust types ${formatListForSentence(trustTypes)}`);
+    }
+
+    if (regions.length === 1) {
+        parts.push(`${regions[0]} region`);
+    } else if (regions.length > 1) {
+        parts.push(`regions ${formatListForSentence(regions)}`);
+    }
+
+    if (icbs.length === 1) {
+        parts.push(icbs[0]);
+    } else if (icbs.length > 1) {
+        parts.push(`ICBs ${formatListForSentence(icbs)}`);
+    }
+
+    if (cancerAlliances.length === 1) {
+        parts.push(`${cancerAlliances[0]} cancer alliance`);
+    } else if (cancerAlliances.length > 1) {
+        parts.push(`cancer alliances ${formatListForSentence(cancerAlliances)}`);
+    }
+
+    if (scopeFilters.shelford === 'in') {
+        parts.push('Shelford Group trusts');
+    } else if (scopeFilters.shelford === 'not_in') {
+        parts.push('trusts outside the Shelford Group');
+    }
+
+    return parts.join('; ');
+}
+
+export function getChartExplainerText(mode, options = {}) {
+    const {
+        hasSelectedOrganisations = false,
+        currentModeHasData = true,
+        vmpsCount = 0,
+        selectedOrganisationsCount = 0,
+        scope = ANALYSIS_SCOPE.ALL,
+        inScopeTrustCount = null,
+        scopeFilterDescription = ''
+    } = options;
+    const {
+        scope: resolvedScope,
+        inScopePopulation,
+        defaultPopulation,
+        singleSelectedTrust,
+        productTrustContext,
+        groupedTrustContext,
+    } = createScopeCopyContext({
+        scope,
+        inScopeTrustCount,
+        scopeFilterDescription,
+        hasSelectedOrganisations,
+        selectedOrganisationsCount,
+    });
+
+    const baseExplainers = {
+        'trust': () => {
+            if (hasSelectedOrganisations) {
+                if (currentModeHasData) {
+                    if (singleSelectedTrust) {
+                        return "This chart shows quantities over time for your selected NHS Trust.";
+                    }
+                    return "This chart shows individual NHS Trust quantities over time for your selected trusts. Each line represents one trust, allowing you to compare their usage patterns.";
+                }
+                if (singleSelectedTrust) {
+                    return "This chart would show NHS Trust quantities, but the selected trust has no data for these products.";
+                }
+                return "This chart would show individual NHS Trust quantities, but the selected trusts have no data for these products.";
+            }
+            if (resolvedScope === ANALYSIS_SCOPE.GROUP) {
+                return `This chart shows individual NHS Trust quantities over time. Each line represents one trust in the scope for this analysis, allowing you to compare usage patterns across ${inScopePopulation}.`;
+            }
+            return "This chart shows individual NHS Trust quantities over time. Each line represents one trust, allowing you to compare usage patterns across different trusts.";
+        },
+
+        'icb': () => {
+            return `This chart shows quantities grouped by integrated care board (ICB) over time. Each line represents one ICB, combining data from ${defaultPopulation} within that area.`;
+        },
+
+        'region': () => {
+            return `This chart shows quantities grouped by NHS region over time. Each line represents one region, combining data from ${defaultPopulation} within that area.`;
+        },
+
+        'national': () => {
+            if (resolvedScope === ANALYSIS_SCOPE.GROUP) {
+                return `This chart shows the total quantities over time across ${inScopePopulation}.`;
+            }
+            if (resolvedScope === ANALYSIS_SCOPE.TRUST) {
+                return "This chart shows the total quantities over time for your selected NHS Trust.";
+            }
+            return `This chart shows the total national quantities over time, combining data from ${defaultPopulation}.`;
+        },
+
+        'product': () => {
+            if (vmpsCount > 1) {
+                return `This chart compares quantities between different products over time. Each line represents one product, showing its total usage ${productTrustContext}.`;
+            }
+            return `This chart shows quantities for the selected product over time ${productTrustContext}.`;
+        },
+
+        'productGroup': () => {
+            return `This chart shows quantities grouped by product category (VTM - Virtual Therapeutic Moiety) over time ${groupedTrustContext}. Each line represents a therapeutic group, combining all related products.`;
+        },
+
+        'ingredient': () => {
+            return `This chart shows quantities grouped by active ingredient over time ${groupedTrustContext}. Each line represents one ingredient, combining the amount of that ingredient in the selected products.`;
+        },
+
+        'unit': () => {
+            return `This chart shows quantities grouped by unit of measurement over time ${groupedTrustContext}. Each line represents one unit type (e.g., tablets, bottles, ampoules).`;
+        }
+    };
+
+    const explainerFunc = baseExplainers[mode];
+    if (explainerFunc) {
+        return explainerFunc();
+    }
+
+    return "This chart shows the selected data over time.";
+}
+
+export function getTableExplainerText(mode, options = {}) {
+    const {
+        hasSelectedTrusts = false,
+        selectedTrustsCount = 0,
+        selectedPeriod = 'all',
+        latestMonth = '',
+        latestYear = '',
+        dateRange = '',
+        scope = ANALYSIS_SCOPE.ALL,
+        inScopeTrustCount = null,
+        scopeFilterDescription = ''
+    } = options;
+    const {
+        scope: resolvedScope,
+        inScopePopulation,
+        defaultPopulation,
+        singleSelectedTrust,
+        selectedTrustsPhrase,
+        otherTrustsLabel,
+    } = createScopeCopyContext({
+        scope,
+        inScopeTrustCount,
+        scopeFilterDescription,
+        hasSelectedOrganisations: hasSelectedTrusts,
+        selectedOrganisationsCount: selectedTrustsCount,
+    });
+    const filteredAmongSuffix = resolvedScope === ANALYSIS_SCOPE.GROUP
+        ? ` among ${inScopePopulation}`
+        : '';
+
+    function getPeriodText() {
+        switch (selectedPeriod) {
+            case 'all':
+                return dateRange ? `across the period ${dateRange}` : 'across the entire period';
+            case 'latest_month':
+                return latestMonth ? `for ${latestMonth}` : 'for the latest month';
+            case 'latest_year':
+                return latestYear ? `for ${latestYear}` : 'for the latest year';
+            case 'current_fy':
+                if (latestMonth) {
+                    const latestDate = new Date(latestMonth);
+                    const fyStartYear = latestDate.getMonth() >= 3
+                        ? latestDate.getFullYear()
+                        : latestDate.getFullYear() - 1;
+                    return `for the current financial year to date (April ${fyStartYear} - ${latestMonth})`;
+                }
+                return 'for the current financial year to date';
+            case 'last_12_months':
+                return 'for the last 12 months';
+            default:
+                return 'across the entire period';
+        }
+    }
+
+    const periodText = getPeriodText();
+
+    const baseExplainers = {
+        'trust': () => {
+            if (resolvedScope === ANALYSIS_SCOPE.TRUST) {
+                return `This table shows the total quantities of the selected products issued by your selected NHS Trust ${periodText}.`;
+            }
+            if (hasSelectedTrusts) {
+                if (singleSelectedTrust) {
+                    return `This table shows the total quantities of the selected products issued by NHS trust ${periodText}. Data is grouped into "Selected trust" and "${otherTrustsLabel}", allowing you to compare your selected NHS Trust against others${filteredAmongSuffix}.`;
+                }
+                return `This table shows the total quantities of the selected products issued by NHS trust ${periodText}. Data is grouped into "Selected trusts" (${selectedTrustsCount} trusts) and "${otherTrustsLabel}", allowing you to compare your selected NHS trusts against others${filteredAmongSuffix}.`;
+            }
+            if (resolvedScope === ANALYSIS_SCOPE.GROUP) {
+                return `This table shows the total quantities of the selected products issued by NHS trust ${periodText} for ${inScopePopulation}.`;
+            }
+            return `This table shows the total quantities of the selected products issued by NHS trust ${periodText} for ${defaultPopulation}.`;
+        },
+
+        'region': () => {
+            if (resolvedScope === ANALYSIS_SCOPE.GROUP) {
+                return `This table shows the total quantities of the selected products issued by ${inScopePopulation}, grouped by NHS region ${periodText}.`;
+            }
+            return `This table shows the total quantities of the selected products issued across ${defaultPopulation}, grouped by NHS region ${periodText}.`;
+        },
+
+        'icb': () => {
+            if (resolvedScope === ANALYSIS_SCOPE.GROUP) {
+                return `This table shows the total quantities of the selected products issued by ${inScopePopulation}, grouped by integrated care board (ICB) ${periodText}.`;
+            }
+            return `This table shows the total quantities of the selected products issued across ${defaultPopulation}, grouped by integrated care board (ICB) ${periodText}.`;
+        },
+
+        'national': () => {
+            if (resolvedScope === ANALYSIS_SCOPE.GROUP) {
+                return `This table shows the total quantity of the selected products issued by ${inScopePopulation} ${periodText}.`;
+            }
+            if (resolvedScope === ANALYSIS_SCOPE.TRUST) {
+                return `This table shows the total quantity of the selected products issued by your selected NHS Trust ${periodText}.`;
+            }
+            return `This table shows the total national quantity of the selected products issued across ${defaultPopulation} ${periodText}.`;
+        },
+
+        'product': () => {
+            if (hasSelectedTrusts) {
+                return `This table shows the total quantities of each of the selected products issued ${periodText}, filtered to only include data from ${selectedTrustsPhrase}.`;
+            }
+            return `This table shows the total quantities of each of the selected products issued ${periodText}, across ${defaultPopulation}.`;
+        },
+
+        'productGroup': () => {
+            if (hasSelectedTrusts) {
+                return `This table shows the total quantities of the selected products issued by product group ${periodText}, filtered to only include data from ${selectedTrustsPhrase}.`;
+            }
+            return `This table shows the total quantities of the selected products issued by product group ${periodText} across ${defaultPopulation}.`;
+        },
+
+        'ingredient': () => {
+            if (hasSelectedTrusts) {
+                return `This table shows total quantities by active ingredient ${periodText}, filtered to only include data from ${selectedTrustsPhrase}.`;
+            }
+            return `This table shows total quantities by active ingredient ${periodText} across ${defaultPopulation}.`;
+        },
+
+        'unit': () => {
+            if (hasSelectedTrusts) {
+                return `This table shows total quantities by unit of measurement ${periodText}, filtered to only include data from ${selectedTrustsPhrase}.`;
+            }
+            return `This table shows total quantities by unit of measurement ${periodText} across ${defaultPopulation}.`;
+        }
+    };
+
+    const explainerFunc = baseExplainers[mode];
+    if (explainerFunc) {
+        return explainerFunc();
+    }
+
+    return `This table shows the total quantities of the selected products issued ${periodText}.`;
+}
+
+export function getPercentileChartIntroText({
+    selectedOrganisationsCount = 0,
+    currentModeHasData = true,
+    singleSelectedTrust = false,
+    isFilteredScope = false,
+    percentilePopulationLabel = 'all NHS Trusts',
+} = {}) {
+    const trustScope = isFilteredScope ? 'in-scope trusts' : 'all trusts';
+
+    if (selectedOrganisationsCount <= 0) {
+        const bandScope = isFilteredScope ? 'trusts in scope' : 'trusts';
+        return `This chart shows percentile ranges across ${percentilePopulationLabel} with data for the selected products. The bands represent the variation in quantities across ${bandScope}.`;
+    }
+
+    if (currentModeHasData) {
+        return singleSelectedTrust
+            ? `This chart shows the selected NHS Trust quantity overlaid on percentile ranges. The selected trust appears as a coloured line, while percentile bands show the distribution across ${trustScope} with data.`
+            : `This chart shows individual NHS Trust quantities overlaid on percentile ranges. Selected trusts appear as coloured lines, while percentile bands show the distribution across ${trustScope} with data.`;
+    }
+
+    return singleSelectedTrust
+        ? `This chart shows percentile ranges across ${percentilePopulationLabel} with data. The selected trust has no data for these products, but percentile bands show the distribution across ${trustScope} with data.`
+        : `This chart shows percentile ranges across ${percentilePopulationLabel} with data. The selected trusts have no data for these products, but percentile bands show the distribution across ${trustScope} with data.`;
 }

--- a/src/components/analyse/lib/analysisScope.js
+++ b/src/components/analyse/lib/analysisScope.js
@@ -1,0 +1,135 @@
+export const ANALYSIS_SCOPE = {
+    ALL: 'all',
+    NATIONAL: 'national',
+    SINGLE: 'single',
+    FILTERED: 'filtered',
+};
+
+export const SCOPE_OPTIONS = Object.values(ANALYSIS_SCOPE);
+
+export const TRUST_PERCENTILE_MIN_COUNT = 30;
+export const TRUST_OVERLAY_MAX_COUNT = 30;
+
+export function normaliseScope(scopeValue) {
+    if (!scopeValue || typeof scopeValue !== 'string') return ANALYSIS_SCOPE.ALL;
+    const candidate = scopeValue.trim().toLowerCase();
+    return SCOPE_OPTIONS.includes(candidate) ? candidate : ANALYSIS_SCOPE.ALL;
+}
+
+export function resolveAnalysisCohort(scope, {
+    selectedItems = [],
+    availableItems = [],
+    allItems = [],
+} = {}) {
+    const normalisedScope = normaliseScope(scope);
+
+    if (normalisedScope === ANALYSIS_SCOPE.FILTERED) {
+        return Array.from(availableItems || []);
+    }
+    if (normalisedScope === ANALYSIS_SCOPE.SINGLE) {
+        return (selectedItems || []).slice(0, 1);
+    }
+    if (normalisedScope === ANALYSIS_SCOPE.NATIONAL) {
+        return [];
+    }
+    return Array.from(allItems || []);
+}
+
+export function getScopedTrustCodes(scope, selectedTrustNames = [], {
+    getOrgCode,
+    availableItems = [],
+} = {}) {
+    const normalisedScope = normaliseScope(scope);
+    const uniqueSelectedTrusts = Array.from(new Set((selectedTrustNames || []).filter(Boolean)));
+    const selectedTrustCodes = uniqueSelectedTrusts
+        .map(name => getOrgCode?.(name))
+        .filter(Boolean);
+
+    if (normalisedScope === ANALYSIS_SCOPE.SINGLE) {
+        return selectedTrustCodes;
+    }
+
+    if (normalisedScope === ANALYSIS_SCOPE.FILTERED) {
+        return Array.from(new Set(
+            Array.from(availableItems || [])
+                .map(name => getOrgCode?.(name))
+                .filter(Boolean)
+        ));
+    }
+
+    return [];
+}
+
+export function resolveNextOverlaySelection(scope, {
+    selectedItems = [],
+    overlayOrganisations,
+} = {}) {
+    const normalisedScope = normaliseScope(scope);
+    if (normalisedScope === ANALYSIS_SCOPE.SINGLE) {
+        return (selectedItems || []).slice(0, 1);
+    }
+    if (Array.isArray(overlayOrganisations)) {
+        return overlayOrganisations;
+    }
+    return [];
+}
+
+export function isNarrowedAnalysisScope(scope) {
+    return scope === ANALYSIS_SCOPE.SINGLE || scope === ANALYSIS_SCOPE.FILTERED;
+}
+
+export function getNationalModeLabel(scope, { longForm = false } = {}) {
+    if (isNarrowedAnalysisScope(scope)) return 'Total';
+    return longForm ? 'National Total' : 'National';
+}
+
+export function buildAnalysisRequestPayload({
+    selectedProducts = [],
+    quantityType = null,
+    scope = ANALYSIS_SCOPE.ALL,
+    odsCodes = [],
+}) {
+    return {
+        names: selectedProducts,
+        quantity_type: quantityType,
+        scope,
+        ods_codes: Array.isArray(odsCodes) ? odsCodes : [],
+    };
+}
+
+export function arePercentilesDisabled(scope, trustCount = 0) {
+    const normalisedScope = normaliseScope(scope);
+    return normalisedScope === ANALYSIS_SCOPE.SINGLE
+        || (normalisedScope === ANALYSIS_SCOPE.FILTERED && trustCount < TRUST_PERCENTILE_MIN_COUNT);
+}
+
+export function computePercentileScopeConstraints({
+    scope = ANALYSIS_SCOPE.ALL,
+    inScopeTrusts = [],
+    selectedOrganisations = [],
+    showPercentiles = false,
+    mode = null,
+} = {}) {
+    const trusts = Array.isArray(inScopeTrusts) ? inScopeTrusts : [];
+    const disabled = arePercentilesDisabled(scope, trusts.length);
+    const patches = {
+        resultsStore: null,
+        selectedOrganisations: null,
+        percentilesDisabled: disabled,
+    };
+
+    if (disabled && showPercentiles) {
+        patches.resultsStore = { showPercentiles: false };
+    }
+
+    if (
+        disabled
+        && mode === 'trust'
+        && trusts.length > 0
+        && (selectedOrganisations || []).length === 0
+    ) {
+        patches.selectedOrganisations = trusts;
+    }
+
+    return patches;
+}

--- a/src/components/analyse/lib/chartOverlay.js
+++ b/src/components/analyse/lib/chartOverlay.js
@@ -1,0 +1,354 @@
+import { formatArrayParam, parseArrayParam } from '../../../utils/utils.js';
+import { isAggregationChartMode, TRUST_OVERLAY_MAX_COUNT } from './analysisScope.js';
+
+export const CHART_OVERLAY_NONE = 'none';
+
+export const OVERLAY_KIND = {
+    ALL: 'all',
+    SELECTED: 'selected',
+};
+
+export function allOverlaySelection() {
+    return { kind: OVERLAY_KIND.ALL };
+}
+
+export function selectedOverlaySelection(items = []) {
+    return {
+        kind: OVERLAY_KIND.SELECTED,
+        items: Array.isArray(items) ? [...items] : [],
+    };
+}
+
+export function normaliseOverlaySelection(rawValue) {
+    if (rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue)
+        && rawValue.kind === OVERLAY_KIND.SELECTED) {
+        return selectedOverlaySelection(rawValue.items);
+    }
+    return allOverlaySelection();
+}
+
+export function isAllOverlaySelection(selection) {
+    return normaliseOverlaySelection(selection).kind === OVERLAY_KIND.ALL;
+}
+
+export function overlaySelectionItems(selection, availableItems = []) {
+    const normalised = normaliseOverlaySelection(selection);
+    if (normalised.kind === OVERLAY_KIND.ALL) {
+        return Array.from(availableItems || []);
+    }
+    return normalised.items;
+}
+
+export function encodeChartOverlayParam(selection, codeByName) {
+    const normalised = normaliseOverlaySelection(selection);
+    if (normalised.kind === OVERLAY_KIND.ALL) return null;
+    if (normalised.items.length === 0) return CHART_OVERLAY_NONE;
+    const codes = Array.from(new Set(
+        normalised.items.map(name => codeByName.get(name) || name).filter(Boolean)
+    )).sort();
+    return codes.length > 0 ? formatArrayParam(codes) : CHART_OVERLAY_NONE;
+}
+
+export function parseChartOverlayParam(rawValue, nameByCode) {
+    if (rawValue == null) return allOverlaySelection();
+    const trimmed = String(rawValue).trim();
+    if (!trimmed || trimmed.toLowerCase() === CHART_OVERLAY_NONE) {
+        return selectedOverlaySelection([]);
+    }
+    return selectedOverlaySelection(
+        parseArrayParam(trimmed).map(value => nameByCode.get(value) || value).filter(Boolean)
+    );
+}
+
+export function isDefaultAllSelection(selectedItems = [], availableItems = []) {
+    const sortedSelected = [...(selectedItems || [])].sort();
+    const sortedAvailable = [...(availableItems || [])].sort();
+    return sortedSelected.length > 0
+        && sortedSelected.length === sortedAvailable.length
+        && sortedSelected.every((value, index) => value === sortedAvailable[index]);
+}
+
+export function toStoredOverlaySelection(selectedItems = [], availableItems = []) {
+    const nextSelection = Array.isArray(selectedItems) ? selectedItems : [];
+    if (isDefaultAllSelection(nextSelection, availableItems)) {
+        return allOverlaySelection();
+    }
+    return selectedOverlaySelection(nextSelection);
+}
+
+export function uniqueFieldValues(data, key) {
+    return Array.from(new Set(
+        (data || []).map(item => item?.[key]).filter(Boolean)
+    )).sort();
+}
+
+export function filterDatasetsByOverlaySelection(datasets = [], selected = []) {
+    const selectedSet = new Set(selected);
+    return datasets.filter(dataset => selectedSet.has(dataset.label));
+}
+
+export function syncDimensionSelection({
+    available = [],
+    selected = [],
+    selection = allOverlaySelection(),
+} = {}) {
+    const availableItems = Array.isArray(available) ? available : [];
+    const normalised = normaliseOverlaySelection(selection);
+    const baseSelected = normalised.kind === OVERLAY_KIND.ALL
+        ? [...availableItems]
+        : (selected || []).filter(item => availableItems.includes(item));
+    const validSelected = normalised.kind === OVERLAY_KIND.ALL
+        ? [...availableItems]
+        : baseSelected;
+    const selectionChanged = normalised.kind === OVERLAY_KIND.ALL
+        ? false
+        : validSelected.length !== (selected || []).length
+            || validSelected.some((item, index) => item !== (selected || [])[index]);
+
+    if (validSelected.length === 0 && availableItems.length > 0) {
+        return {
+            selected: [...availableItems],
+            selection: normalised.kind === OVERLAY_KIND.SELECTED
+                ? allOverlaySelection()
+                : normalised,
+            storeValue: normalised.kind === OVERLAY_KIND.SELECTED
+                ? allOverlaySelection()
+                : undefined,
+            didChange: true,
+        };
+    }
+
+    if (selectionChanged && normalised.kind === OVERLAY_KIND.SELECTED) {
+        const storeValue = toStoredOverlaySelection(validSelected, availableItems);
+        return {
+            selected: validSelected,
+            selection: storeValue,
+            storeValue,
+            didChange: true,
+        };
+    }
+
+    if (selectionChanged) {
+        return {
+            selected: validSelected,
+            selection: allOverlaySelection(),
+            storeValue: undefined,
+            didChange: true,
+        };
+    }
+
+    return {
+        selected: validSelected,
+        selection: normalised,
+        storeValue: undefined,
+        didChange: false,
+    };
+}
+
+export function clampTrustOverlaySelection(items = [], maxCount = TRUST_OVERLAY_MAX_COUNT) {
+    if (!Array.isArray(items)) return [];
+    return items.length > maxCount ? items.slice(0, maxCount) : items;
+}
+
+export function nextStashedOverlayState(currentSelected = [], currentRemembered = []) {
+    const current = Array.isArray(currentSelected) ? currentSelected : [];
+    if (current.length === 0) {
+        return {
+            selectedOrganisations: [],
+            rememberedOverlayOrganisations: Array.isArray(currentRemembered) ? currentRemembered : [],
+        };
+    }
+    return {
+        selectedOrganisations: [],
+        rememberedOverlayOrganisations: clampTrustOverlaySelection(current),
+    };
+}
+
+export function nextRestoredOverlayState(currentSelected = [], remembered = []) {
+    const selected = Array.isArray(currentSelected) ? currentSelected : [];
+    const rememberedItems = Array.isArray(remembered) ? remembered : [];
+    if (selected.length > 0 || rememberedItems.length === 0) {
+        return null;
+    }
+    return {
+        selectedOrganisations: clampTrustOverlaySelection(rememberedItems),
+    };
+}
+
+export function overlayTrustsForModeChange(fromMode, toMode, {
+    selectedOrganisations = [],
+    rememberedOverlayOrganisations = [],
+} = {}) {
+    if (isAggregationChartMode(toMode) && !isAggregationChartMode(fromMode)) {
+        return {
+            type: 'stash',
+            patch: nextStashedOverlayState(selectedOrganisations, rememberedOverlayOrganisations),
+        };
+    }
+    if (!isAggregationChartMode(toMode) && isAggregationChartMode(fromMode)) {
+        const restored = nextRestoredOverlayState(
+            selectedOrganisations,
+            rememberedOverlayOrganisations
+        );
+        return restored
+            ? { type: 'restore', patch: restored }
+            : { type: 'none', patch: null };
+    }
+    return { type: 'none', patch: null };
+}
+
+export function commitDimensionSelection(selectedItems = [], availableItems = []) {
+    const nextSelection = Array.isArray(selectedItems) ? selectedItems : [];
+    return {
+        selected: nextSelection,
+        selection: toStoredOverlaySelection(nextSelection, availableItems),
+    };
+}
+
+export function hydrateOverlayLocals(storeSelection, availableItems = []) {
+    const selection = normaliseOverlaySelection(storeSelection);
+    return {
+        selected: overlaySelectionItems(selection, availableItems),
+        selection,
+    };
+}
+
+export function resolveChartOverlayLocals(analyseOptions, selectedData = []) {
+    const regionAvailable = uniqueFieldValues(selectedData, 'organisation__region');
+    const icbAvailable = uniqueFieldValues(selectedData, 'organisation__icb');
+    const regions = hydrateOverlayLocals(analyseOptions.selectedChartRegions, regionAvailable);
+    const icbs = hydrateOverlayLocals(analyseOptions.selectedChartIcbs, icbAvailable);
+    return {
+        selectedRegions: regions.selected,
+        regionOverlaySelection: regions.selection,
+        selectedIcbs: icbs.selected,
+        icbOverlaySelection: icbs.selection,
+    };
+}
+
+export function commitChartDimensionSelection(dimension, selectedItems, availableItems = []) {
+    const nextSelection = Array.isArray(selectedItems) ? selectedItems : [];
+    if (nextSelection.length === 0) {
+        return null;
+    }
+    const committed = commitDimensionSelection(nextSelection, availableItems);
+    return {
+        dimension,
+        selected: committed.selected,
+        selection: committed.selection,
+    };
+}
+
+export function buildResultsModeSearchSync({
+    selectedMode,
+    availableTrusts = [],
+    selectedOrganisations = [],
+    selectedRegions = [],
+    selectedIcbs = [],
+    regionOverlaySelection,
+    icbOverlaySelection,
+    selectedData = [],
+} = {}) {
+    if (selectedMode === 'trust') {
+        const cappedOrganisations = clampTrustOverlaySelection(selectedOrganisations);
+        return {
+            filterType: 'trust',
+            availableItems: availableTrusts,
+            selectedItems: cappedOrganisations,
+            selectedOrganisations: cappedOrganisations.length !== selectedOrganisations.length
+                ? cappedOrganisations
+                : undefined,
+            selectedRegions,
+            selectedIcbs,
+            regionOverlaySelection,
+            icbOverlaySelection,
+            chartRegionsStoreValue: undefined,
+            chartIcbsStoreValue: undefined,
+        };
+    }
+
+    if (selectedMode !== 'region' && selectedMode !== 'icb') {
+        return null;
+    }
+
+    const field = selectedMode === 'region' ? 'organisation__region' : 'organisation__icb';
+    const availableItems = uniqueFieldValues(selectedData, field);
+    const localSelected = selectedMode === 'region' ? selectedRegions : selectedIcbs;
+    const selection = selectedMode === 'region' ? regionOverlaySelection : icbOverlaySelection;
+    const synced = syncDimensionSelection({
+        available: availableItems,
+        selected: localSelected,
+        selection,
+    });
+
+    return {
+        filterType: selectedMode,
+        availableItems,
+        selectedItems: synced.selected,
+        selectedOrganisations: undefined,
+        selectedRegions: selectedMode === 'region' ? synced.selected : selectedRegions,
+        selectedIcbs: selectedMode === 'icb' ? synced.selected : selectedIcbs,
+        regionOverlaySelection: selectedMode === 'region' ? synced.selection : regionOverlaySelection,
+        icbOverlaySelection: selectedMode === 'icb' ? synced.selection : icbOverlaySelection,
+        chartRegionsStoreValue: selectedMode === 'region' ? synced.storeValue : undefined,
+        chartIcbsStoreValue: selectedMode === 'icb' ? synced.storeValue : undefined,
+    };
+}
+
+export function buildOrganisationSelectionPatch({
+    selectedMode,
+    selectedItems = [],
+    selectedData = [],
+    selectedRegions = [],
+    selectedIcbs = [],
+} = {}) {
+    if (selectedMode === 'trust') {
+        const nextSelection = clampTrustOverlaySelection(selectedItems);
+        return {
+            type: 'trust',
+            selectedOrganisations: nextSelection,
+            searchSelection: nextSelection,
+        };
+    }
+
+    if (selectedMode === 'region' || selectedMode === 'icb') {
+        const field = selectedMode === 'region' ? 'organisation__region' : 'organisation__icb';
+        const availableItems = uniqueFieldValues(selectedData, field);
+        const committed = commitChartDimensionSelection(selectedMode, selectedItems, availableItems);
+        if (!committed) {
+            return {
+                type: 'revert',
+                searchSelection: selectedMode === 'region' ? selectedRegions : selectedIcbs,
+            };
+        }
+        return {
+            type: selectedMode,
+            selected: committed.selected,
+            selection: committed.selection,
+            searchSelection: committed.selected,
+            availableItems,
+        };
+    }
+
+    return null;
+}
+
+export function applyResultsModeSearchSync(sync, {
+    analyseOptions,
+    resultsModeSearchStore,
+    assignLocals,
+} = {}) {
+    if (!sync) return;
+    assignLocals?.(sync);
+    if (sync.selectedOrganisations !== undefined) {
+        analyseOptions.setSelectedOrganisations(sync.selectedOrganisations);
+    }
+    if (sync.chartRegionsStoreValue !== undefined) {
+        analyseOptions.setSelectedChartRegions(sync.chartRegionsStoreValue);
+    }
+    if (sync.chartIcbsStoreValue !== undefined) {
+        analyseOptions.setSelectedChartIcbs(sync.chartIcbsStoreValue);
+    }
+    resultsModeSearchStore.setItems(sync.availableItems, sync.filterType);
+    resultsModeSearchStore.updateSelection(sync.selectedItems);
+}

--- a/src/components/analyse/lib/resultsChartPipeline.js
+++ b/src/components/analyse/lib/resultsChartPipeline.js
@@ -1,0 +1,227 @@
+import pluralize from 'pluralize';
+import { formatNumber } from '../../../utils/utils.js';
+import { ChartDataProcessor, calculatePercentiles } from './analyseData.js';
+import { filterDatasetsByOverlaySelection } from './chartOverlay.js';
+
+export function formatUnitForTooltip(baseUnit, value) {
+    if (!baseUnit) return 'units';
+
+    if (baseUnit.startsWith('DDD (') && baseUnit.includes(')')) {
+        const doseMatch = baseUnit.match(/^DDD (\(.+\))$/);
+        if (doseMatch) {
+            const doseInfo = doseMatch[1];
+            return value === 1 ? `DDD ${doseInfo}` : `DDDs ${doseInfo}`;
+        }
+    }
+
+    if (baseUnit === 'DDD') {
+        return value === 1 ? 'DDD' : 'DDDs';
+    }
+
+    return pluralize(baseUnit, value);
+}
+
+const TOOLTIP_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export function formatChartTooltipDate(date) {
+    const d = new Date(date);
+    return `${TOOLTIP_MONTHS[d.getMonth()]} ${d.getFullYear()}`;
+}
+
+export function buildResultsTooltipContent(d, { vmps = [], yAxisLabel = 'units' } = {}) {
+    const label = d.dataset.label || 'No label';
+    const value = d.value;
+    let unit;
+    if (d.dataset.isProduct && vmps.length > 0) {
+        const matchingVmp = vmps.find(vmp => vmp.vmp === d.dataset.label);
+        unit = formatUnitForTooltip(matchingVmp?.unit || yAxisLabel || 'unit', value);
+    } else {
+        unit = formatUnitForTooltip(yAxisLabel || 'units', value);
+    }
+
+    const tooltipContent = [
+        { text: label, class: 'font-medium' },
+        { label: 'Date', value: formatChartTooltipDate(d.date) },
+        { label: 'Value', value: `${formatNumber(value)} ${unit}` },
+    ];
+
+    if (
+        (d.dataset.isOrganisation || d.dataset.isProduct || d.dataset.isProductGroup)
+        && d.dataset.numerator !== undefined
+        && d.dataset.denominator !== undefined
+    ) {
+        tooltipContent.push(
+            { label: 'Numerator', value: formatNumber(d.dataset.numerator[d.index], { addCommas: true }) },
+            { label: 'Denominator', value: formatNumber(d.dataset.denominator[d.index], { addCommas: true }) },
+        );
+    }
+
+    return tooltipContent;
+}
+
+export function buildChartExportOrganisations(selectedOrgNames, availableTrusts, orgMaps = {}) {
+    const allNames = (selectedOrgNames && selectedOrgNames.length > 0)
+        ? selectedOrgNames
+        : availableTrusts;
+    const {
+        orgCodes = new Map(),
+        orgRegions = new Map(),
+        orgIcbs = new Map(),
+        trustTypes = new Map(),
+    } = orgMaps;
+
+    return allNames.map(name => ({
+        name,
+        code: orgCodes.get?.(name) ?? null,
+        region: orgRegions.get?.(name) ?? null,
+        icb: orgIcbs.get?.(name) ?? null,
+        trustType: trustTypes.get?.(name) ?? null,
+    }));
+}
+
+export function buildVmpsFromSelectedData(selectedData = [], searchType) {
+    const vmpGroups = selectedData.reduce((acc, item) => {
+        const key = item.vmp__name;
+        if (!acc[key]) {
+            acc[key] = {
+                vmp: item.vmp__name,
+                code: item.vmp__code,
+                vtm: item.vmp__vtm__name,
+                ingredients: item.ingredient_names || [],
+                units: new Set(),
+                searchType,
+            };
+        }
+        if (item.unit) {
+            acc[key].units.add(item.unit);
+        }
+        return acc;
+    }, {});
+
+    return Object.values(vmpGroups)
+        .filter(vmp => vmp.vmp)
+        .map(vmp => ({
+            ...vmp,
+            unit: vmp.units.size > 0 ? Array.from(vmp.units).join(', ') : 'nan',
+            ingredients: Array.isArray(vmp.ingredients) ? vmp.ingredients : (vmp.ingredients || []),
+            vtm: vmp.vtm || '',
+        }));
+}
+
+function resolveYAxisLabel(uniqueUnits, combinedUnits) {
+    if (uniqueUnits.length === 1) {
+        const unit = uniqueUnits[0];
+        if (unit && unit.startsWith('DDD (')) return 'DDDs';
+        if (unit === 'DDD') return 'DDDs';
+        return pluralize(unit);
+    }
+    if (uniqueUnits.length > 1) {
+        const allDDD = uniqueUnits.every(unit => unit && unit.startsWith('DDD ('));
+        return allDDD ? 'DDDs' : combinedUnits;
+    }
+    return 'units';
+}
+
+export function buildResultsChartPipeline({
+    data,
+    mode,
+    aggregatedData,
+    months = [],
+    selectedOrganisations = [],
+    availableTrusts = [],
+    showPercentiles = true,
+    percentilesDisabled = false,
+    scope = 'all',
+    selectedRegions = [],
+    selectedIcbs = [],
+} = {}) {
+    const effectiveSelectedOrganisations = selectedOrganisations.length > 0
+        ? selectedOrganisations
+        : (percentilesDisabled ? availableTrusts : []);
+
+    const processor = new ChartDataProcessor(
+        data,
+        aggregatedData,
+        {
+            months,
+            selectedOrganisations: effectiveSelectedOrganisations,
+            showPercentiles: showPercentiles !== false,
+            scope,
+        }
+    );
+
+    const { datasets: chartDatasets, maxValue, needsPercentiles, percentilesData } = processor.processMode(mode);
+    const combinedUnits = processor.getCombinedUnits();
+    let finalDatasets = chartDatasets;
+    let percentilesPatch = {
+        percentiles: [],
+        trustCount: 0,
+        excludedTrusts: [],
+    };
+
+    if (mode === 'trust' && needsPercentiles && showPercentiles) {
+        const percentilesResult = calculatePercentiles(
+            percentilesData,
+            availableTrusts,
+            months
+        );
+        percentilesPatch = {
+            percentiles: percentilesResult.percentiles,
+            trustCount: percentilesResult.trustCount,
+            excludedTrusts: percentilesResult.excludedTrusts,
+        };
+        if (percentilesResult.percentiles.length > 0) {
+            const percentileDatasets = processor.createPercentileDatasets(percentilesResult.percentiles);
+            finalDatasets = [...percentileDatasets, ...chartDatasets];
+        }
+    }
+
+    if (mode === 'region') {
+        finalDatasets = filterDatasetsByOverlaySelection(finalDatasets, selectedRegions);
+    }
+    if (mode === 'icb') {
+        finalDatasets = filterDatasetsByOverlaySelection(finalDatasets, selectedIcbs);
+    }
+
+    const yAxisLabel = resolveYAxisLabel(processor.uniqueUnits, combinedUnits);
+
+    const chartConfig = {
+        mode,
+        yAxisLabel,
+        yAxisRange: maxValue > 0 ? [0, maxValue] : [0, 100],
+        visibleItems: new Set(finalDatasets.map(d => d.label)),
+        yAxisBehavior: {
+            forceZero: true,
+            padTop: 1.1,
+            resetToInitial: true,
+        },
+        yAxisTickFormat: value => {
+            const range = maxValue;
+            let decimals = 1;
+            if (typeof value === 'number' && !isNaN(value)) {
+                const step = range / 10;
+                if (step > 0) {
+                    decimals = Math.min(
+                        Math.max(1, Math.ceil(Math.abs(Math.log10(step))) + 1),
+                        5
+                    );
+                }
+            }
+            return formatNumber(value, { maxDecimals: decimals });
+        },
+        tooltipValueFormat: value => {
+            const baseUnit = combinedUnits || 'units';
+            const pluralizedUnit = formatUnitForTooltip(baseUnit, value);
+            return formatNumber(value, { showUnit: true, unit: pluralizedUnit });
+        },
+    };
+
+    return {
+        chartData: {
+            labels: processor.allDates,
+            datasets: finalDatasets,
+        },
+        chartConfig,
+        percentilesPatch,
+    };
+}

--- a/src/components/analyse/lib/runAnalysis.js
+++ b/src/components/analyse/lib/runAnalysis.js
@@ -1,0 +1,175 @@
+import {
+    ANALYSIS_SCOPE,
+    resolveAnalysisCohort,
+    getScopedTrustCodes,
+    resolveNextOverlaySelection,
+    buildAnalysisRequestPayload,
+} from './analysisScope.js';
+import {
+    createEmptyScopeFilters,
+    hasAnyScopeFilters,
+    normaliseScopeFilters,
+} from '../../../utils/scopeFilters.js';
+
+export function validateAnalysisRun({
+    selectedVMPs = [],
+    selectedScope = ANALYSIS_SCOPE.ALL,
+    selectedTrusts = [],
+    selectedScopeFilters = createEmptyScopeFilters(),
+    availableItems = [],
+} = {}) {
+    if (!selectedVMPs || selectedVMPs.length === 0) {
+        return 'Please select at least one product or ingredient.';
+    }
+    if (selectedScope === ANALYSIS_SCOPE.TRUST && selectedTrusts.length === 0) {
+        return 'Please select a trust for your single-trust analysis.';
+    }
+    if (selectedScope === ANALYSIS_SCOPE.GROUP && !hasAnyScopeFilters(selectedScopeFilters)) {
+        return 'Please select at least one filter to define your trust group.';
+    }
+    if (
+        selectedScope === ANALYSIS_SCOPE.GROUP
+        && Array.from(availableItems || []).length === 0
+    ) {
+        return 'No trusts match the selected filters. Adjust your filters and try again.';
+    }
+    return null;
+}
+
+export function buildAnalysisRunPlan({
+    selectedScope = ANALYSIS_SCOPE.ALL,
+    selectedItems = [],
+    availableItems = [],
+    allItems = [],
+    selectedTrusts = [],
+    getOrgCode,
+    overlayOrganisations,
+} = {}) {
+    const cohortTrusts = resolveAnalysisCohort(selectedScope, {
+        selectedItems,
+        availableItems,
+        allItems,
+    });
+    const odsCodes = getScopedTrustCodes(selectedScope, selectedTrusts, {
+        getOrgCode,
+        availableItems,
+    });
+    const hasExplicitOverlay = Array.isArray(overlayOrganisations);
+    const nextOverlaySelection = resolveNextOverlaySelection(selectedScope, {
+        selectedItems,
+        overlayOrganisations: hasExplicitOverlay ? overlayOrganisations : undefined,
+    });
+
+    return {
+        cohortTrusts,
+        odsCodes,
+        hasExplicitOverlay,
+        nextOverlaySelection,
+    };
+}
+
+export function buildAnalysisResultsUpdateOptions({
+    searchType,
+    quantityType,
+    selectedScope,
+    selectedScopeFilters,
+    plan,
+    showPercentilesFromUrl = null,
+    excludedVmps = [],
+} = {}) {
+    const updateOptions = {
+        searchType,
+        quantityType,
+        selectedOrganisations: plan.nextOverlaySelection,
+        scope: selectedScope,
+        scopeFilters: selectedScope === ANALYSIS_SCOPE.GROUP
+            ? normaliseScopeFilters(selectedScopeFilters)
+            : createEmptyScopeFilters(),
+        inScopeTrusts: plan.cohortTrusts,
+    };
+
+    if (showPercentilesFromUrl !== null) {
+        updateOptions.showPercentiles = showPercentilesFromUrl === 'true';
+    }
+    if (excludedVmps.length > 0) {
+        updateOptions.excludedVmps = excludedVmps;
+    }
+    return updateOptions;
+}
+
+export async function executeAnalysisFetch({
+    fetchImpl = fetch,
+    endpoint = '/api/get-quantity-data/',
+    csrftoken,
+    resolvedProducts,
+    quantityType,
+    selectedScope,
+    odsCodes,
+} = {}) {
+    const response = await fetchImpl(endpoint, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': csrftoken,
+        },
+        body: JSON.stringify(
+            buildAnalysisRequestPayload({
+                selectedProducts: resolvedProducts,
+                quantityType,
+                scope: selectedScope,
+                odsCodes,
+            })
+        ),
+    });
+
+    if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || `HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return { months: data.months ?? [], items: data.items ?? [] };
+}
+
+export function completeAnalysisRun({
+    plan,
+    payload,
+    selectedVMPs = [],
+    searchType,
+    quantityType,
+    selectedScope = ANALYSIS_SCOPE.ALL,
+    selectedScopeFilters = createEmptyScopeFilters(),
+    showPercentilesFromUrl = null,
+    excludedVmps = [],
+    analyseOptions,
+    updateResults,
+} = {}) {
+    analyseOptions.setSelectedOrganisations(plan.nextOverlaySelection);
+    if (!plan.hasExplicitOverlay && selectedScope !== ANALYSIS_SCOPE.TRUST) {
+        analyseOptions.setRememberedOverlayOrganisations([]);
+    }
+    analyseOptions.runAnalysis({
+        selectedVMPs,
+        searchType,
+        selectedOrganisations: plan.nextOverlaySelection,
+    });
+
+    updateResults(
+        payload,
+        buildAnalysisResultsUpdateOptions({
+            searchType,
+            quantityType,
+            selectedScope,
+            selectedScopeFilters,
+            plan,
+            showPercentilesFromUrl,
+            excludedVmps,
+        })
+    );
+
+    return {
+        data: payload,
+        searchType,
+        selectedOrganisations: plan.nextOverlaySelection,
+    };
+}

--- a/src/components/analyse/results/AnalysisResults.svelte
+++ b/src/components/analyse/results/AnalysisResults.svelte
@@ -1,36 +1,56 @@
-<svelte:options customElement={{
-    tag: 'analysis-results',
-    shadow: 'none'
-  }} />
+<svelte:options runes={false} customElement={{ tag: 'analysis-results', shadow: 'none' }} />
 
 <script>
     import { onDestroy, onMount } from 'svelte';
     import TotalsTable from './TotalsTable.svelte';
     import ProductsTable from './ProductsTable.svelte';
+    import ResultsChartControls from './ResultsChartControls.svelte';
     import { resultsStore } from '../../../stores/resultsStore';
     import { analyseOptions } from '../../../stores/analyseOptionsStore';
     import Chart from '../../common/Chart.svelte';
-    import { modeSelectorStore } from '../../../stores/modeSelectorStore';
-    import { chartConfig } from '../../../utils/chartConfig.js';
-    import ModeSelector from '../../common/ModeSelector.svelte';
+    import { modeSelectorStore, reconcileSelectedMode, selectDefaultMode } from '../../../stores/modeSelectorStore';
     import { createChartStore } from '../../../stores/chartStore';
     import { organisationSearchStore } from '../../../stores/organisationSearchStore';
-    import { formatNumber, getCurrentUrl, copyToClipboard, getUrlParams } from '../../../utils/utils';
-    import { normaliseMode } from '../../../utils/analyseUtils.js';
-    import pluralize from 'pluralize';
-    import { ChartDataProcessor, ViewModeCalculator, selectDefaultMode, processTableDataByMode, calculatePercentiles, getTrustCount, getChartExplainerText } from '../../../utils/analyseUtils.js';
+    import { createResultsModeSearchStore } from '../../../stores/resultsModeSearchStore';
+    import { getCurrentUrl, copyToClipboard, getUrlParams } from '../../../utils/utils';
+    import { ViewModeCalculator, processTableDataByMode } from '../lib/analyseData.js';
+    import {
+        ANALYSIS_SCOPE,
+        arePercentilesDisabled,
+        computePercentileScopeConstraints,
+        getChartExplainerText,
+        getPercentileChartIntroText,
+        formatScopeFilterDescription,
+        formatInScopePopulationPhrase,
+        normaliseMode,
+        isAggregationChartMode,
+    } from '../lib/analysisScope.js';
+    import {
+        allOverlaySelection,
+        resolveChartOverlayLocals,
+        commitChartDimensionSelection as commitChartDimensionSelectionHelper,
+        buildOrganisationSelectionPatch,
+        applyResultsModeSearchSync,
+        buildResultsModeSearchSync,
+        clampTrustOverlaySelection,
+    } from '../lib/chartOverlay.js';
+    import {
+        buildResultsChartPipeline,
+        buildResultsTooltipContent,
+        buildChartExportOrganisations,
+        buildVmpsFromSelectedData,
+    } from '../lib/resultsChartPipeline.js';
 
-  export let className = '';
-  export let isAnalysisRunning;
-  export let analysisData;
-  export let showResults;
-  export let urlValidationErrors = [];
+    export let className = '';
+    export let urlValidationErrors = [];
+    export let isAuthenticated = false;
+
+    $: isAuth = isAuthenticated === true || isAuthenticated === 'true';
 
     let selectedData = [];
     let vmps = [];
     let filteredData = [];
     let viewModes = [];
-    let viewModeCalculator;
     let isCopyingShareLink = false;
     let showShareToast = false;
     let shareToastMessage = '';
@@ -40,11 +60,15 @@
     let showTrustCountDetails = false;
     let modeFromUrl = null;
     let isModeFromUrlApplied = false;
+    let previousSelectedMode = null;
+    let availableTrusts = [];
+    let selectedRegions = [];
+    let selectedIcbs = [];
+    let regionOverlaySelection = allOverlaySelection();
+    let icbOverlaySelection = allOverlaySelection();
 
     if (typeof window !== 'undefined') {
-        const params = getUrlParams();
-        const modeParam = params.get('mode');
-        modeFromUrl = normaliseMode(modeParam);
+        modeFromUrl = normaliseMode(getUrlParams().get('mode'));
     }
 
     const resultsChartStore = createChartStore({
@@ -52,12 +76,9 @@
         yAxisLabel: 'units',
         yAxisRange: [0, 100],
         visibleItems: new Set(),
-        yAxisBehavior: {
-            forceZero: true,
-            padTop: 1.1,
-            resetToInitial: true
-        }
+        yAxisBehavior: { forceZero: true, padTop: 1.1, resetToInitial: true }
     });
+    const resultsModeSearchStore = createResultsModeSearchStore();
 
     onMount(() => {
         resultsChartStore.setDimensions({
@@ -66,83 +87,167 @@
         });
     });
 
+    onDestroy(() => {
+        if (shareToastTimeout) clearTimeout(shareToastTimeout);
+    });
+
     $: excludedVmps = Array.isArray($resultsStore.excludedVmps) ? $resultsStore.excludedVmps : [];
+    $: analysisScope = $resultsStore.scope || ANALYSIS_SCOPE.ALL;
+    $: availableTrusts = Array.isArray($resultsStore.inScopeTrusts) ? $resultsStore.inScopeTrusts : [];
+    $: isFilteredScope = analysisScope === ANALYSIS_SCOPE.GROUP;
+    $: isTrustScope = analysisScope === ANALYSIS_SCOPE.TRUST;
+    $: scopeFilterDescription = isFilteredScope
+        ? formatScopeFilterDescription($resultsStore.scopeFilters || {})
+        : '';
+    $: inScopeTrustCount = availableTrusts.length;
+    $: inScopeTrustLabel = isFilteredScope ? 'in-scope trusts' : 'trusts';
+    $: percentilePopulationLabel = isFilteredScope
+        ? formatInScopePopulationPhrase({
+            trustCount: inScopeTrustCount,
+            filterDescription: scopeFilterDescription,
+            includeArticle: false
+        })
+        : 'all NHS Trusts';
+    $: isOverlaySelectionScope = [ANALYSIS_SCOPE.ALL, ANALYSIS_SCOPE.GROUP].includes(analysisScope);
+    $: hasRegionMode = viewModes.some(mode => mode.value === 'region');
+    $: hasIcbMode = viewModes.some(mode => mode.value === 'icb');
+    $: shouldShowOrganisationSearch = isAuth && (
+        ($modeSelectorStore.selectedMode === 'trust' && isOverlaySelectionScope) ||
+        ($modeSelectorStore.selectedMode === 'region' && hasRegionMode) ||
+        ($modeSelectorStore.selectedMode === 'icb' && hasIcbMode)
+    );
+    $: percentilesDisabled = arePercentilesDisabled(analysisScope, availableTrusts.length);
+    $: trustPercentileToggleDisabled = percentilesDisabled || !$analyseOptions.selectedOrganisations?.length;
+
+    function assignOverlayLocals(next) {
+        selectedRegions = next.selectedRegions;
+        selectedIcbs = next.selectedIcbs;
+        regionOverlaySelection = next.regionOverlaySelection;
+        icbOverlaySelection = next.icbOverlaySelection;
+    }
+
+    function syncResultsUi({ enforceConstraints = false } = {}) {
+        let selectedOrganisations = $analyseOptions.selectedOrganisations || [];
+        if (enforceConstraints) {
+            const patches = computePercentileScopeConstraints({
+                scope: $resultsStore.scope || ANALYSIS_SCOPE.ALL,
+                inScopeTrusts: $resultsStore.inScopeTrusts,
+                selectedOrganisations,
+                showPercentiles: $resultsStore.showPercentiles,
+                mode: $modeSelectorStore.selectedMode,
+            });
+            if (patches.resultsStore) {
+                resultsStore.update(store => ({ ...store, ...patches.resultsStore }));
+            }
+            if (patches.selectedOrganisations) {
+                analyseOptions.setSelectedOrganisations(patches.selectedOrganisations);
+                selectedOrganisations = patches.selectedOrganisations;
+            }
+        }
+
+        const sync = buildResultsModeSearchSync({
+            selectedMode: $modeSelectorStore.selectedMode,
+            availableTrusts,
+            selectedOrganisations,
+            selectedRegions,
+            selectedIcbs,
+            regionOverlaySelection,
+            icbOverlaySelection,
+            selectedData,
+        });
+        applyResultsModeSearchSync(sync, {
+            analyseOptions,
+            resultsModeSearchStore,
+            assignLocals: assignOverlayLocals,
+        });
+    }
+
+    function rebuildChart({ forceUpdate = false, data = null } = {}) {
+        const chartSource = data
+            ?? ($resultsStore.filteredData?.length > 0 ? $resultsStore.filteredData : selectedData);
+        if (!$modeSelectorStore.selectedMode || !chartSource?.length) return;
+
+        const scope = $resultsStore.scope || ANALYSIS_SCOPE.ALL;
+        const selectedOrganisations = $analyseOptions.selectedOrganisations || [];
+        const showPercentiles = $resultsStore.showPercentiles;
+        const overridesPercentilesDisabled = arePercentilesDisabled(scope, availableTrusts.length);
+        const overrides = {
+            percentilesDisabled: overridesPercentilesDisabled,
+            showPercentiles: overridesPercentilesDisabled ? false : showPercentiles,
+            selectedOrganisations: clampTrustOverlaySelection(selectedOrganisations),
+            selectedRegions,
+            selectedIcbs,
+        };
+        const chartData = processChartData(chartSource, overrides);
+        if (forceUpdate) {
+            resultsChartStore.setData({ ...chartData, forceUpdate: Date.now() });
+        }
+    }
+
+    function handleModeChange(nextMode) {
+        if (previousSelectedMode !== null && previousSelectedMode !== nextMode) {
+            analyseOptions.applyOverlayModeChange(previousSelectedMode, nextMode);
+        }
+        previousSelectedMode = nextMode;
+        syncResultsUi({ enforceConstraints: true });
+        rebuildChart();
+    }
+
+    function applySelectedMode(nextMode) {
+        const fromMode = $modeSelectorStore.selectedMode;
+        if (fromMode !== nextMode) {
+            if (fromMode !== null) {
+                analyseOptions.applyOverlayModeChange(fromMode, nextMode);
+            }
+            modeSelectorStore.setSelectedMode(nextMode);
+        }
+        previousSelectedMode = nextMode;
+        syncResultsUi({ enforceConstraints: true });
+        rebuildChart();
+    }
 
     function hasValidData(item) {
-        if (!item?.data || !Array.isArray(item.data)) return false;
-        return item.data.some(v => v > 0 && !isNaN(parseFloat(v)));
-    }
-
-    $: if (analysisData) {
-        handleUpdateData(analysisData);
-    }
-
-    $: {
-        resultsStore.update(store => ({
-            ...store,
-            isAnalysisRunning,
-            showResults,
-            analysisData
-        }));
-    }
-
-    $: if (selectedData && selectedData.length > 0 && $modeSelectorStore.selectedMode) {
-        processChartData(selectedData);
+        return Array.isArray(item?.data) && item.data.some(v => v > 0 && !isNaN(parseFloat(v)));
     }
 
     $: currentModeHasData = (() => {
-        if (!selectedData || !Array.isArray(selectedData) || selectedData.length === 0) return false;
-        
+        if (!selectedData?.length) return false;
         if ($modeSelectorStore.selectedMode === 'trust') {
             const selectedOrgNames = new Set($analyseOptions.selectedOrganisations || []);
-            
-            // If no trusts are selected, check if there's any data available for percentiles
-            if (selectedOrgNames.size === 0) {
-                return selectedData.some(item => hasValidData(item));
-            }
-            
-            // If trusts are selected, check if selected trusts have data
-            return selectedData.filter(item => selectedOrgNames.has(item.organisation__ods_name))
-                .some(item => hasValidData(item));
+            if (selectedOrgNames.size === 0) return selectedData.some(hasValidData);
+            return selectedData
+                .filter(item => selectedOrgNames.has(item.organisation__ods_name))
+                .some(hasValidData);
         }
-
         const tableData = processTableDataByMode(
-            selectedData, 
-            $modeSelectorStore.selectedMode, 
+            selectedData,
+            $modeSelectorStore.selectedMode,
             'all',
             $resultsStore.aggregatedData,
             null,
             $analyseOptions.selectedOrganisations || [],
             $organisationSearchStore.items || [],
             $resultsStore.analysisMonths || [],
-            $organisationSearchStore.regionsHierarchy || []
+            $organisationSearchStore.regionsHierarchy || [],
+            $resultsStore.scope || 'all'
         );
-        
-        return tableData && tableData.length > 0 && tableData.some(entry => entry.total > 0);
+        return tableData?.length > 0 && tableData.some(entry => entry.total > 0);
     })();
 
-    $: isInTrustModeWithNoData = $modeSelectorStore.selectedMode === 'trust' && 
-           $analyseOptions.selectedOrganisations?.length > 0 &&
-           !currentModeHasData &&
-           !$resultsStore.showPercentiles;
-
-    $: canShowPercentilesWithoutTrustData = $modeSelectorStore.selectedMode === 'trust' &&
-           $analyseOptions.selectedOrganisations?.length > 0 &&
-           !currentModeHasData &&
-           $resultsStore.showPercentiles;
-
-    let colorMappings = new Map();
-
+    $: isInTrustModeWithNoData = $modeSelectorStore.selectedMode === 'trust'
+        && $analyseOptions.selectedOrganisations?.length > 0
+        && !currentModeHasData
+        && !$resultsStore.showPercentiles;
+    $: canShowPercentilesWithoutTrustData = $modeSelectorStore.selectedMode === 'trust'
+        && $analyseOptions.selectedOrganisations?.length > 0
+        && !currentModeHasData
+        && $resultsStore.showPercentiles;
 
     function showShareFeedback(message, variant = 'success') {
         shareToastMessage = message;
         shareToastVariant = variant;
         showShareToast = true;
-
-        if (shareToastTimeout) {
-            clearTimeout(shareToastTimeout);
-        }
-
+        if (shareToastTimeout) clearTimeout(shareToastTimeout);
         shareToastTimeout = setTimeout(() => {
             showShareToast = false;
             shareToastTimeout = null;
@@ -151,12 +256,9 @@
 
     async function handleCopyAnalysisLink() {
         if (isCopyingShareLink) return;
-
         isCopyingShareLink = true;
-
         try {
-            const currentUrl = getCurrentUrl();
-            await copyToClipboard(currentUrl);
+            await copyToClipboard(getCurrentUrl());
             showShareFeedback('Analysis link copied to clipboard!', 'success');
         } catch (error) {
             console.error('Failed to copy analysis link:', error);
@@ -166,152 +268,83 @@
         }
     }
 
-    onDestroy(() => {
-        if (shareToastTimeout) {
-            clearTimeout(shareToastTimeout);
-        }
-    });
-
-
-    function processChartData(data) {
-        const months = $resultsStore.analysisMonths || [];
-        const processor = new ChartDataProcessor(
+    function processChartData(data, overrides = {}) {
+        const { chartData, chartConfig, percentilesPatch } = buildResultsChartPipeline({
             data,
-            $resultsStore.aggregatedData,
-            {
-                months,
-                selectedOrganisations: $analyseOptions.selectedOrganisations,
-                showPercentiles: $resultsStore.showPercentiles !== false
-            }
-        );
-
-        const { datasets: chartDatasets, maxValue, needsPercentiles, percentilesData } = processor.processMode($modeSelectorStore.selectedMode);
-        const combinedUnits = processor.getCombinedUnits();
-
-        let finalDatasets = chartDatasets;
-        
-        if ($modeSelectorStore.selectedMode === 'trust' && needsPercentiles && $resultsStore.showPercentiles) {
-            const percentilesResult = calculatePercentiles(
-                percentilesData, 
-                $organisationSearchStore.items,
-                $resultsStore.analysisMonths || []
-            );
-            
-            const trustCount = getTrustCount(percentilesResult);
-
-            resultsStore.update(store => ({
-                ...store,
-                percentiles: percentilesResult.percentiles,
-                trustCount,
-                excludedTrusts: percentilesResult.excludedTrusts
-            }));
-
-            if (percentilesResult.percentiles.length > 0) {
-                const percentileDatasets = processor.createPercentileDatasets(percentilesResult.percentiles);
-                finalDatasets = [...percentileDatasets, ...chartDatasets];
-            }
-        }
-
-        let yAxisLabel;
-        if (processor.uniqueUnits.length === 1) {
-            const unit = processor.uniqueUnits[0];
-
-            if (unit && unit.startsWith('DDD (')) {
-                yAxisLabel = 'DDDs';
-            } else if (unit === 'DDD') {
-                yAxisLabel = 'DDDs';
-            } else {
-                yAxisLabel = pluralize(unit);
-            }
-        } else if (processor.uniqueUnits.length > 1) {
-
-            const allDDD = processor.uniqueUnits.every(unit => unit && unit.startsWith('DDD ('));
-            if (allDDD) {
-                yAxisLabel = 'DDDs';
-            } else {
-                yAxisLabel = combinedUnits;
-            }
-        } else {
-            yAxisLabel = 'units';
-        }
-
-        const chartConfig = {
             mode: $modeSelectorStore.selectedMode,
-            yAxisLabel: yAxisLabel,
-            yAxisRange: maxValue > 0 ? [0, maxValue] : [0, 100],
-            visibleItems: new Set(finalDatasets.map(d => d.label)),
-            yAxisBehavior: {
-                forceZero: true,
-                padTop: 1.1,
-                resetToInitial: true
-            },
-            yAxisTickFormat: value => {
-                const range = maxValue;
-                let decimals = 1;
-                if (typeof value === 'number' && !isNaN(value)) {
-                    const step = range / 10;
-                    if (step > 0) {
-                        decimals = Math.min(
-                            Math.max(1, Math.ceil(Math.abs(Math.log10(step))) + 1),
-                            5
-                        );
-                    }
-                }
-                return formatNumber(value, { maxDecimals: decimals });
-            },
-            tooltipValueFormat: value => {
-                const baseUnit = combinedUnits || 'units';
-                const pluralizedUnit = formatUnitForTooltip(baseUnit, value);
-                return formatNumber(value, { showUnit: true, unit: pluralizedUnit });
-            }
-        };
-
-        const chartData = {
-            labels: processor.allDates,
-            datasets: finalDatasets
-        };
-
+            aggregatedData: $resultsStore.aggregatedData,
+            months: $resultsStore.analysisMonths || [],
+            selectedOrganisations: overrides.selectedOrganisations
+                ?? (Array.isArray($analyseOptions.selectedOrganisations)
+                    ? $analyseOptions.selectedOrganisations
+                    : []),
+            availableTrusts,
+            showPercentiles: overrides.showPercentiles ?? $resultsStore.showPercentiles,
+            percentilesDisabled: overrides.percentilesDisabled ?? percentilesDisabled,
+            scope: $resultsStore.scope || 'all',
+            selectedRegions: overrides.selectedRegions ?? selectedRegions,
+            selectedIcbs: overrides.selectedIcbs ?? selectedIcbs,
+        });
+        resultsStore.update(store => ({ ...store, ...percentilesPatch }));
         resultsChartStore.setData(chartData);
         resultsChartStore.setConfig(chartConfig);
-
         return chartData;
     }
 
-    function handleUpdateData(data) {
-        const payload = data.data;
-        selectedData = Array.isArray(payload?.items) ? payload.items : [];
-        
-        try {
-            const vmpGroups = selectedData.reduce((acc, item) => {
-                const key = item.vmp__name;
-                if (!acc[key]) {
-                    acc[key] = {
-                        vmp: item.vmp__name,
-                        code: item.vmp__code,
-                        vtm: item.vmp__vtm__name,
-                        ingredients: item.ingredient_names || [],
-                        units: new Set(),
-                        searchType: data.searchType || $analyseOptions.searchType
-                    };
-                }
-                if (item.unit) {
-                    acc[key].units.add(item.unit);
-                }
-                return acc;
-            }, {});
+    function applyChartOverlaySelectionFromStore() {
+        ({
+            selectedRegions,
+            regionOverlaySelection,
+            selectedIcbs,
+            icbOverlaySelection,
+        } = resolveChartOverlayLocals($analyseOptions, selectedData));
+    }
 
-            vmps = Object.values(vmpGroups)
-                .filter(vmp => vmp.vmp) // Filter out undefined VMPs
-                .map(vmp => ({
-                    ...vmp,
-                    unit: vmp.units.size > 0 ? Array.from(vmp.units).join(', ') : 'nan',
-                    ingredients: Array.isArray(vmp.ingredients) ? vmp.ingredients : (vmp.ingredients || []),
-                    vtm: vmp.vtm || '',
-                }));
+    function commitChartDimensionSelection(dimension, selectedItems, availableItems = []) {
+        const committed = commitChartDimensionSelectionHelper(dimension, selectedItems, availableItems);
+        if (!committed) return false;
+        if (dimension === 'region') {
+            selectedRegions = committed.selected;
+            regionOverlaySelection = committed.selection;
+            analyseOptions.setSelectedChartRegions(committed.selection);
+            return true;
+        }
+        selectedIcbs = committed.selected;
+        icbOverlaySelection = committed.selection;
+        analyseOptions.setSelectedChartIcbs(committed.selection);
+        return true;
+    }
+
+    function recalculateViewModes(vmpsWithValidData) {
+        if (vmpsWithValidData.length === 0) {
+            viewModes = [];
+            modeSelectorStore.setSelectedMode(null);
+            return [];
+        }
+        const calculator = new ViewModeCalculator(
+            $resultsStore,
+            $analyseOptions,
+            $organisationSearchStore,
+            vmpsWithValidData,
+            $resultsStore.scope || 'all',
+            isAuth
+        );
+        viewModes = calculator.calculateAvailableModes();
+        return viewModes;
+    }
+
+    function handleUpdateData(data) {
+        selectedData = Array.isArray(data.data?.items) ? data.data.items : [];
+        applyChartOverlaySelectionFromStore();
+
+        try {
+            vmps = buildVmpsFromSelectedData(
+                selectedData,
+                data.searchType || $analyseOptions.searchType
+            );
 
             const availableCodes = new Set(vmps.map(vmp => String(vmp.code ?? '')));
             const currentExcluded = Array.isArray($resultsStore.excludedVmps) ? $resultsStore.excludedVmps : [];
-            const filteredExcluded = currentExcluded.filter(code => availableCodes.has(String(code)));
 
             resultsStore.update(store => ({
                 ...store,
@@ -319,204 +352,183 @@
                 showResults: true,
                 searchType: data.searchType || $analyseOptions.searchType,
                 quantityType: data.quantityType || $analyseOptions.quantityType,
-                excludedVmps: filteredExcluded
+                excludedVmps: currentExcluded.filter(code => availableCodes.has(String(code)))
             }));
 
-            const vmpsWithValidData = vmps.filter(vmp => vmp.unit !== 'nan');
+            if (!isModeFromUrlApplied && isAggregationChartMode(modeFromUrl)) {
+                analyseOptions.applyOverlayModeChange($modeSelectorStore.selectedMode, modeFromUrl);
+            }
 
-            viewModeCalculator = new ViewModeCalculator(
-                $resultsStore,
-                $analyseOptions,
-                $organisationSearchStore,
-                vmpsWithValidData
-            );
+            const nextViewModes = recalculateViewModes(vmps.filter(vmp => vmp.unit !== 'nan'));
 
-            viewModes = viewModeCalculator.calculateAvailableModes();
-
-            if (viewModes.length > 0) {
-                const hasSelectedOrganisations = $analyseOptions.selectedOrganisations && 
-                                               $analyseOptions.selectedOrganisations.length > 0;
-                const availableModeValues = viewModes.map(mode => mode.value);
+            if (nextViewModes.length > 0) {
+                const availableModeValues = nextViewModes.map(mode => mode.value);
                 let nextMode = null;
 
                 if (!isModeFromUrlApplied) {
                     if (modeFromUrl && availableModeValues.includes(modeFromUrl)) {
                         nextMode = modeFromUrl;
                     }
-
                     isModeFromUrlApplied = true;
                     modeFromUrl = null;
                 }
 
                 if (!nextMode) {
                     const currentMode = $modeSelectorStore.selectedMode;
-                    if (currentMode && availableModeValues.includes(currentMode)) {
-                        nextMode = currentMode;
-                    } else {
-                        nextMode = selectDefaultMode(viewModes, hasSelectedOrganisations);
-                    }
+                    nextMode = currentMode && availableModeValues.includes(currentMode)
+                        ? currentMode
+                        : selectDefaultMode(nextViewModes, $resultsStore.scope || 'all');
                 }
-                
-                modeSelectorStore.setSelectedMode(nextMode);
+
+                applySelectedMode(nextMode);
             } else {
-                modeSelectorStore.setSelectedMode(null);
+                syncResultsUi({ enforceConstraints: true });
+                rebuildChart();
             }
         } catch (error) {
-            console.error("Error processing data:", error);
+            console.error('Error processing data:', error);
         }
     }
 
     function handleFilteredData(event) {
         const selectedVMPs = event.detail;
-
-        filteredData = selectedData.filter(item => 
+        filteredData = selectedData.filter(item =>
             selectedVMPs.some(vmp => vmp.vmp === item.vmp__name)
         );
 
-        // Recalculate available view modes based on selected VMPs
-        const filteredVMPs = vmps.filter(vmp => 
+        const filteredVMPs = vmps.filter(vmp =>
             selectedVMPs.some(selectedVmp => selectedVmp.vmp === vmp.vmp)
         );
+        const nextViewModes = recalculateViewModes(filteredVMPs.filter(vmp => vmp.unit !== 'nan'));
 
-        const vmpsWithValidData = filteredVMPs.filter(vmp => vmp.unit !== 'nan');
+        resultsStore.update(store => ({ ...store, filteredData }));
 
-        if (vmpsWithValidData.length > 0) {
-            viewModeCalculator = new ViewModeCalculator(
-                $resultsStore,
-                $analyseOptions,
-                $organisationSearchStore,
-                vmpsWithValidData
+        if (nextViewModes.length > 0) {
+            const reconciledMode = reconcileSelectedMode(
+                $modeSelectorStore.selectedMode,
+                nextViewModes
             );
-
-            const newViewModes = viewModeCalculator.calculateAvailableModes();
-            viewModes = newViewModes;
-
-            // Check if current mode is still available, if not select new default
-            const currentModeStillAvailable = newViewModes.some(mode => 
-                mode.value === $modeSelectorStore.selectedMode
-            );
-
-            if (!currentModeStillAvailable && newViewModes.length > 0) {
-                const hasSelectedOrganisations = $analyseOptions.selectedOrganisations && 
-                                               $analyseOptions.selectedOrganisations.length > 0;
-                const newDefaultMode = selectDefaultMode(newViewModes, hasSelectedOrganisations);
-                modeSelectorStore.setSelectedMode(newDefaultMode);
+            if (reconciledMode === null) {
+                applySelectedMode(selectDefaultMode(nextViewModes, $resultsStore.scope || 'all'));
+            } else if (reconciledMode !== $modeSelectorStore.selectedMode) {
+                applySelectedMode(reconciledMode);
+            } else {
+                syncResultsUi();
+                rebuildChart({ forceUpdate: true, data: filteredData });
             }
         } else {
-            viewModes = [];
-            modeSelectorStore.setSelectedMode(null);
+            syncResultsUi();
+            rebuildChart({ forceUpdate: true, data: filteredData });
         }
-
-        const chartData = processChartData(filteredData);
-
-        resultsChartStore.setData({
-            ...chartData,
-            forceUpdate: Date.now()
-        });
-
-        resultsStore.update(store => ({
-            ...store,
-            filteredData
-        }));
     }
 
-    $: if ($modeSelectorStore.selectedMode && selectedData.length > 0) {
-        
-        const dataToProcess = $resultsStore.filteredData && $resultsStore.filteredData.length > 0 ? 
-            $resultsStore.filteredData : selectedData;
-        
-        processChartData(dataToProcess);
+    export function loadAnalysis(detail) {
+        handleUpdateData(detail);
     }
 
-    $: if (analysisData) {
-        handleUpdateData(analysisData);
+    export function prepareForNewRun() {
+        selectedData = [];
+        filteredData = [];
+        vmps = [];
+        viewModes = [];
+        previousSelectedMode = null;
     }
 
-    $: if (analysisData) {
-        colorMappings.clear();
-        handleUpdateData(analysisData);
-    }
-
-    function formatDate(date) {
-        const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-        const d = new Date(date);
-        return `${months[d.getMonth()]} ${d.getFullYear()}`;
-    }
-
-    function formatUnitForTooltip(baseUnit, value) {
-        if (!baseUnit) return 'units';
-        
-        // Handle DDD units with dose information like "DDD (60.0mg)"
-        if (baseUnit.startsWith('DDD (') && baseUnit.includes(')')) {
-            const doseMatch = baseUnit.match(/^DDD (\(.+\))$/);
-            if (doseMatch) {
-                const doseInfo = doseMatch[1];
-                return value === 1 ? `DDD ${doseInfo}` : `DDDs ${doseInfo}`;
+    export function syncOverlayFromBuilder() {
+        if (!selectedData.length || !$modeSelectorStore.selectedMode) return;
+        const nextViewModes = recalculateViewModes(vmps.filter(vmp => vmp.unit !== 'nan'));
+        if (nextViewModes.length > 0) {
+            const reconciledMode = reconcileSelectedMode(
+                $modeSelectorStore.selectedMode,
+                nextViewModes
+            );
+            if (reconciledMode === null) {
+                applySelectedMode(selectDefaultMode(nextViewModes, $resultsStore.scope || 'all'));
+                return;
+            }
+            if (reconciledMode !== $modeSelectorStore.selectedMode) {
+                applySelectedMode(reconciledMode);
+                return;
             }
         }
-        
-        // Handle plain "DDD" units
-        if (baseUnit === 'DDD') {
-            return value === 1 ? 'DDD' : 'DDDs';
-        }
-        
-        return pluralize(baseUnit, value);
+        syncResultsUi();
+        rebuildChart({ forceUpdate: true });
     }
 
     function customTooltipFormatter(d) {
-        const label = d.dataset.label || 'No label';
-        const date = formatDate(d.date);
-        const value = d.value;
-        const chartConfig = $resultsChartStore.config;
-        
-        let unit;
-        if (d.dataset.isProduct && vmps.length > 0) {
-            const matchingVmp = vmps.find(vmp => vmp.vmp === d.dataset.label);
-            const baseUnit = matchingVmp?.unit || chartConfig?.yAxisLabel || 'unit';
-            
-            unit = formatUnitForTooltip(baseUnit, value);
-        } else {
-            const baseUnit = chartConfig?.yAxisLabel || 'units';
-            unit = formatUnitForTooltip(baseUnit, value);
-        }
-
-        const tooltipContent = [
-            { text: label, class: 'font-medium' },
-            { label: 'Date', value: date },
-            { label: 'Value', value: `${formatNumber(value)} ${unit}` }
-        ];
-
-        if (d.dataset.isOrganisation || d.dataset.isProduct || d.dataset.isProductGroup) {
-            if (d.dataset.numerator !== undefined && d.dataset.denominator !== undefined) {
-                tooltipContent.push(
-                    { label: 'Numerator', value: formatNumber(d.dataset.numerator[d.index], { addCommas: true }) },
-                    { label: 'Denominator', value: formatNumber(d.dataset.denominator[d.index], { addCommas: true }) }
-                );
-            }
-        }
-
-        return tooltipContent;
+        return buildResultsTooltipContent(d, {
+            vmps,
+            yAxisLabel: $resultsChartStore.config?.yAxisLabel,
+        });
     }
-
 
     function handlePercentileToggle() {
-        if ($modeSelectorStore.selectedMode !== 'trust' || !($analyseOptions.selectedOrganisations?.length > 0)) {
+        if (percentilesDisabled || $modeSelectorStore.selectedMode !== 'trust'
+            || !($analyseOptions.selectedOrganisations?.length > 0)) {
             return;
         }
-        resultsStore.update(store => ({
-            ...store,
-            showPercentiles: !store.showPercentiles
-        }));
+        resultsStore.update(store => ({ ...store, showPercentiles: !store.showPercentiles }));
+        rebuildChart();
     }
 
+    function handleResultsOrganisationSelection(event) {
+        const selectedItems = event?.detail?.selectedItems || [];
+        const patch = buildOrganisationSelectionPatch({
+            selectedMode: $modeSelectorStore.selectedMode,
+            selectedItems,
+            selectedData,
+            selectedRegions,
+            selectedIcbs,
+        });
+        if (!patch) return;
+
+        if (patch.type === 'trust') {
+            analyseOptions.setSelectedOrganisations(patch.selectedOrganisations);
+            analyseOptions.setRememberedOverlayOrganisations(patch.selectedOrganisations);
+            resultsModeSearchStore.updateSelection(patch.searchSelection);
+            syncResultsUi();
+            rebuildChart();
+            return;
+        }
+        if (patch.type === 'revert') {
+            resultsModeSearchStore.updateSelection(patch.searchSelection);
+            return;
+        }
+        if (
+            (patch.type === 'region' || patch.type === 'icb')
+            && commitChartDimensionSelection(patch.type, selectedItems, patch.availableItems)
+        ) {
+            resultsModeSearchStore.updateSelection(
+                patch.type === 'region' ? selectedRegions : selectedIcbs
+            );
+            syncResultsUi();
+            rebuildChart();
+        } else if (patch.type === 'region' || patch.type === 'icb') {
+            resultsModeSearchStore.updateSelection(patch.searchSelection);
+        }
+    }
+
+    $: selectedOrganisationsCount = $analyseOptions.selectedOrganisations?.length || 0;
+    $: singleSelectedTrust = selectedOrganisationsCount === 1;
     $: chartExplainerText = getChartExplainerText($modeSelectorStore.selectedMode, {
-        hasSelectedOrganisations: $analyseOptions.selectedOrganisations?.length > 0,
+        hasSelectedOrganisations: selectedOrganisationsCount > 0,
         currentModeHasData,
-        vmpsCount: vmps.length
+        vmpsCount: vmps.length,
+        selectedOrganisationsCount,
+        scope: $resultsStore.scope || 'all',
+        inScopeTrustCount,
+        scopeFilterDescription
+    });
+    $: percentileIntroText = getPercentileChartIntroText({
+        selectedOrganisationsCount,
+        currentModeHasData,
+        singleSelectedTrust,
+        isFilteredScope,
+        percentilePopulationLabel,
     });
 </script>
 
-{#if showResults || (urlValidationErrors && urlValidationErrors.length > 0)}
+{#if $resultsStore.showResults || (urlValidationErrors && urlValidationErrors.length > 0)}
     <div class="results-box bg-white rounded-lg shadow-md h-full flex flex-col {className}">
         <div class="flex-grow overflow-y-auto rounded-t-lg">
             {#if urlValidationErrors && urlValidationErrors.length > 0}
@@ -545,7 +557,7 @@
                     </div>
                 </div>
             {/if}
-            {#if isAnalysisRunning}
+            {#if $resultsStore.isAnalysisRunning}
                 <div class="flex items-center justify-center h-[500px] p-16">
                     <div class="flex items-center">
                         <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-oxford-600"></div>
@@ -560,84 +572,32 @@
                     
                     {#if viewModes.length > 0}
                     <section class="p-4">
-                        <div class="mb-4">
-                            <div class="flex flex-col sm:items-end mb-2">
-                                <button
-                                    type="button"
-                                    on:click={handleCopyAnalysisLink}
-                                    class="flex items-center gap-2 px-3 py-2 text-sm font-medium text-oxford-600 bg-white border border-oxford-200 rounded-md hover:bg-oxford-50 hover:border-oxford-300 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-oxford-400 disabled:opacity-70 disabled:cursor-not-allowed"
-                                    disabled={isCopyingShareLink}
-                                    title="Copy link to share this analysis with current selections"
-                                >
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935 2.186 2.25 2.25 0 00-3.935-2.186zm0-12.814a2.25 2.25 0 103.935-2.186 2.25 2.25 0 00-3.935 2.186z" />
-                                    </svg>
-                                    {isCopyingShareLink ? 'Copying...' : 'Share analysis'}
-                                </button>
-                            </div>
-                            <div class="flex flex-col sm:flex-row sm:items-center gap-4">
-                                <ModeSelector 
-                                    options={viewModes}
-                                    initialMode={selectDefaultMode(viewModes, $analyseOptions.selectedOrganisations?.length > 0)}
-                                    label="View by"
-                                    variant="pill"
-                                />
-
-                                {#if $modeSelectorStore.selectedMode === 'trust'}
-                                <div class="flex flex-col items-center gap-2">
-                                    <span class="text-sm text-gray-600 leading-tight text-center">
-                                        Show percentiles
-                                    </span>
-                                    <div class="flex items-center gap-2">
-                                        <label class="inline-flex items-center {$analyseOptions.selectedOrganisations?.length > 0 ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
-                                            <input
-                                                type="checkbox"
-                                                class="sr-only peer"
-                                                checked={$resultsStore.showPercentiles}
-                                                disabled={!$analyseOptions.selectedOrganisations?.length}
-                                                on:change={handlePercentileToggle}
-                                            />
-                                            <div class="relative w-9 h-5 bg-gray-200 peer-focus:outline-none {$analyseOptions.selectedOrganisations?.length > 0 ? 'peer-focus:ring-2 peer-focus:ring-blue-500' : ''} rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-blue-600 {$analyseOptions.selectedOrganisations?.length > 0 ? '' : 'peer-disabled:opacity-50'}"></div>
-                                        </label>
-                                        <div class="relative inline-block group">
-                                            <button type="button" aria-label="Percentiles information" class="text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-oxford-500 flex items-center">
-                                                <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                                    <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
-                                                </svg>
-                                            </button>
-                                            <div class="absolute z-10 scale-0 transition-all duration-100 origin-top transform 
-                                                        group-hover:scale-100 w-[280px] -translate-x-1/2 left-1/2 sm:-translate-x-full sm:left-5 top-5 rounded-md shadow-lg bg-white 
-                                                        ring-1 ring-black ring-opacity-5 p-4">
-                                                <p class="text-sm text-gray-500">
-                                                    {#if $analyseOptions.selectedOrganisations?.length > 0}
-                                                        Percentiles show variation in product quantity across NHS Trusts and allow easy comparison of Trust activity relative to the median Trust level. See <a href="/faq/#what-are-percentile-charts" class="underline font-semibold" target="_blank">the FAQs</a> for more details about how to interpret them.
-                                                    {:else}
-                                                        Percentiles are always shown when no trusts are selected. Select trusts to enable this toggle. See <a href="/faq/#what-are-percentile-charts" class="underline font-semibold" target="_blank">the FAQs</a> for more details.
-                                                    {/if}
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                {/if}
-                            </div>
-                        </div>
+                        <ResultsChartControls
+                            {resultsModeSearchStore}
+                            {shouldShowOrganisationSearch}
+                            {availableTrusts}
+                            {viewModes}
+                            {isTrustScope}
+                            {percentilesDisabled}
+                            {trustPercentileToggleDisabled}
+                            {isCopyingShareLink}
+                            on:selectionChange={handleResultsOrganisationSelection}
+                            on:copyLink={handleCopyAnalysisLink}
+                            on:percentileToggle={handlePercentileToggle}
+                            on:modeChange={(e) => handleModeChange(e.detail.mode)}
+                        />
 
                         {#if currentModeHasData || canShowPercentilesWithoutTrustData}
                         <div class="mb-4">
                             <p class="text-sm text-gray-700">
                                 {#if $modeSelectorStore.selectedMode === 'trust' && $resultsStore.showPercentiles}
-                                    {#if $analyseOptions.selectedOrganisations?.length > 0}
-                                        {#if currentModeHasData}
-                                            This chart shows individual NHS Trust quantities overlaid on percentile ranges. Selected trusts appear as colored lines, while percentile bands show the distribution across all trusts with data.
-                                        {:else}
-                                            This chart shows percentile ranges across all NHS Trusts with data. The selected trusts have no data for these products, but percentile bands show the distribution across all trusts with data.
-                                        {/if}
-                                    {:else}
-                                        This chart shows percentile ranges across all NHS Trusts with data for the selected products. The bands represent the variation in quantities across trusts.
-                                    {/if}
+                                    {percentileIntroText}
                                     {#if $resultsStore.trustCount > 0}
-                                        Trusts are only included if they have issued any of the selected products during the time period. For the selected products above, this is <strong>{$resultsStore.trustCount}/{$organisationSearchStore.items.length} trusts</strong>
+                                        {#if isFilteredScope}
+                                            Only in-scope trusts that have issued any of the selected products during the time period are included. For the selected products above, this is <strong>{$resultsStore.trustCount}/{availableTrusts.length} {inScopeTrustLabel}</strong>
+                                        {:else}
+                                            Trusts are only included if they have issued any of the selected products during the time period. For the selected products above, this is <strong>{$resultsStore.trustCount}/{availableTrusts.length} trusts</strong>
+                                        {/if}
                                         {#if $resultsStore.excludedTrusts && $resultsStore.excludedTrusts.length > 0}
                                             <button
                                                 type="button"
@@ -649,7 +609,7 @@
                                         {/if}
                                         .
                                     {/if}
-                                    Variation can reflect differences in hospital size rather than genuine variation. 
+                                    Variation can reflect differences in hospital size rather than genuine variation.
                                     See <a href="/faq/#what-are-percentile-charts" class="underline font-semibold" target="_blank">the FAQs</a> for more details about how to interpret this chart.
                                 {:else}
                                     {chartExplainerText}
@@ -703,12 +663,20 @@
                                 <div class="">
                                     <div class="text-center space-y-6">
                                         <div>
-                                            <p class="text-oxford-600 text-xl font-medium mb-3">No data for selected trusts</p>
+                                            <p class="text-oxford-600 text-xl font-medium mb-3">
+                                                {singleSelectedTrust ? 'No data for selected trust' : 'No data for selected trusts'}
+                                            </p>
                                             <p class="text-gray-600 text-base max-w-md mb-4">
-                                                The selected NHS Trusts have no data for the chosen products.
+                                                {singleSelectedTrust
+                                                    ? 'The selected NHS Trust has no data for the chosen products.'
+                                                    : 'The selected NHS Trusts have no data for the chosen products.'}
                                             </p>
                                             <p class="text-gray-600 text-base max-w-md">
-                                                Try <strong>turning on percentiles</strong>, to see variation across all trusts that do have data, or <strong>select more trusts</strong> in the analysis builder. 
+                                                {#if percentilesDisabled}
+                                                    Try <strong>selecting different trusts</strong> above, or choose different products.
+                                                {:else}
+                                                    Try <strong>turning on percentiles</strong>, to see variation across {isFilteredScope ? 'in-scope trusts' : 'all trusts'} that do have data, or <strong>select more trusts</strong> {isAuth ? 'above' : 'in the analysis builder'}.
+                                                {/if}
                                                 <a href="/faq/#why-is-there-no-quantity-for-some-products" class="link-oxford" target="_blank">
                                                     Learn more about why quantities might be missing
                                                 </a>.
@@ -732,26 +700,21 @@
                                             months: $resultsStore.analysisMonths || [],
                                             excludedVmps: $resultsStore.excludedVmps || [],
                                             selectedTrusts: $analyseOptions.selectedOrganisations || null,
-                                            percentilesData: $resultsStore.percentiles || [],
-                                            allOrganisations: (() => {
-                                                const selectedOrgNames = $analyseOptions.selectedOrganisations;
-                                                const allNames = (selectedOrgNames && selectedOrgNames.length > 0)
-                                                    ? selectedOrgNames
-                                                    : ($organisationSearchStore.items || []);
-                                                const orgCodes = $organisationSearchStore.orgCodes || new Map();
-                                                const orgRegions = $organisationSearchStore.orgRegions || new Map();
-                                                const orgIcbs = $organisationSearchStore.orgIcbs || new Map();
-                                                const orgTrustTypes = $organisationSearchStore.trustTypes || new Map();
-                                                return allNames.map(name => {
-                                                    return {
-                                                        name,
-                                                        code: orgCodes.get?.(name) ?? null,
-                                                        region: orgRegions.get?.(name) ?? null,
-                                                        icb: orgIcbs.get?.(name) ?? null,
-                                                        trustType: orgTrustTypes.get?.(name) ?? null
-                                                    };
-                                                });
-                                            })(),
+                                            percentilesData: (
+                                                $modeSelectorStore.selectedMode === 'trust'
+                                                && $resultsStore.showPercentiles
+                                                && !percentilesDisabled
+                                            ) ? ($resultsStore.percentiles || []) : [],
+                                            allOrganisations: buildChartExportOrganisations(
+                                                $analyseOptions.selectedOrganisations,
+                                                availableTrusts,
+                                                {
+                                                    orgCodes: $organisationSearchStore.orgCodes,
+                                                    orgRegions: $organisationSearchStore.orgRegions,
+                                                    orgIcbs: $organisationSearchStore.orgIcbs,
+                                                    trustTypes: $organisationSearchStore.trustTypes,
+                                                }
+                                            ),
                                         }}
                                     />
                                 </div>
@@ -762,7 +725,7 @@
                                     <div>
                                         <p class="text-oxford-600 text-xl font-medium mb-3">No data to display</p>
                                         <p class="text-oxford-400 text-base max-w-md">
-                                            No data was returned for the selected view mode. 
+                                            No data was returned for the selected view mode.
                                             <a href="/faq/#why-is-there-no-quantity-for-some-products" class="text-blue-600 hover:text-blue-800 hover:underline" target="_blank">
                                                 Learn more about why quantities might be missing
                                             </a>.
@@ -804,7 +767,7 @@
                                 <div>
                                     <p class="text-oxford-600 text-xl font-medium mb-3">No data to display</p>
                                     <p class="text-oxford-400 text-base max-w-md">
-                                        No data was returned for the selected quantity type of the chosen products. 
+                                        No data was returned for the selected quantity type of the chosen products.
                                         <a href="/faq/#why-is-there-no-quantity-for-some-products" class="text-blue-600 hover:text-blue-800 hover:underline" target="_blank">
                                             Learn more about why quantities might be missing
                                         </a>.
@@ -813,15 +776,15 @@
                             </div>
                         </div>
                     {/if}
-
-                   
                 </div>
             {:else}
                 <div class="flex items-center justify-center h-[500px] p-6">
                     <div class="text-center space-y-6">
                         <div>
                             <p class="text-oxford-600 text-xl font-medium mb-3">No data to display</p>
-                            <p class="text-oxford-400 text-base max-w-md">The analysis returned no chartable data.</p>
+                            <p class="text-oxford-400 text-base max-w-md">
+                                The analysis returned no chartable data.
+                            </p>
                         </div>
                     </div>
                 </div>
@@ -829,11 +792,15 @@
         </div>
     </div>
 {:else}
-    <div class="flex items-center justify-center h-[500px] p-6 {className}">
-        <div class="text-center space-y-6">
-            <div>
-                <p class="text-oxford-600 text-xl font-medium mb-3">No analysis results to show</p>
-                <p class="text-oxford-400 text-base max-w-md">Please run an analysis to see results here.</p>
+    <div class="{className}">
+        <div class="flex items-center justify-center h-[500px] p-6">
+            <div class="text-center space-y-6">
+                <div>
+                    <p class="text-oxford-600 text-xl font-medium mb-3">No analysis results to show</p>
+                    <p class="text-oxford-400 text-base max-w-md">
+                        Please run an analysis to see results here.
+                    </p>
+                </div>
             </div>
         </div>
     </div>

--- a/src/components/analyse/results/ResultsChartControls.svelte
+++ b/src/components/analyse/results/ResultsChartControls.svelte
@@ -1,0 +1,112 @@
+<svelte:options runes={false} />
+
+<script>
+    import OrganisationSearch from '../../common/OrganisationSearch.svelte';
+    import ModeSelector from '../../common/ModeSelector.svelte';
+    import { modeSelectorStore } from '../../../stores/modeSelectorStore';
+    import { analyseOptions } from '../../../stores/analyseOptionsStore';
+    import { resultsStore } from '../../../stores/resultsStore';
+    import { TRUST_OVERLAY_MAX_COUNT } from '../lib/analysisScope.js';
+    import { createEventDispatcher } from 'svelte';
+
+    export let resultsModeSearchStore;
+    export let shouldShowOrganisationSearch = false;
+    export let availableTrusts = [];
+    export let viewModes = [];
+    export let isTrustScope = false;
+    export let percentilesDisabled = false;
+    export let trustPercentileToggleDisabled = true;
+    export let isCopyingShareLink = false;
+
+    const dispatch = createEventDispatcher();
+
+    $: isTrustMode = $modeSelectorStore.selectedMode === 'trust';
+    $: trustCohortCount = availableTrusts.length > 0
+        ? availableTrusts.length
+        : ($resultsModeSearchStore.availableItems?.size || 0);
+    $: trustMaxItems = isTrustMode ? TRUST_OVERLAY_MAX_COUNT : null;
+    $: trustHideSelectAll = isTrustMode && trustCohortCount > TRUST_OVERLAY_MAX_COUNT;
+    $: hideClearAll = !isTrustMode || percentilesDisabled;
+    $: requireSelection = !isTrustMode;
+</script>
+
+<div class="mb-4">
+    <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 mb-3">
+        {#if shouldShowOrganisationSearch}
+            <div class="w-full md:w-7/12 relative z-10">
+                <OrganisationSearch
+                    source={resultsModeSearchStore}
+                    overlayMode={true}
+                    on:selectionChange
+                    showTitle={false}
+                    maxItems={trustMaxItems}
+                    hideSelectAll={trustHideSelectAll}
+                    hideClearAll={hideClearAll}
+                    requireSelection={requireSelection}
+                />
+            </div>
+        {/if}
+        <button
+            type="button"
+            on:click={() => dispatch('copyLink')}
+            class="sm:ml-auto flex items-center gap-2 px-3 py-2 text-sm font-medium text-oxford-600 bg-white border border-oxford-200 rounded-md hover:bg-oxford-50 hover:border-oxford-300 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-oxford-400 disabled:opacity-70 disabled:cursor-not-allowed"
+            disabled={isCopyingShareLink}
+            title="Copy link to share this analysis with current selections"
+        >
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935 2.186 2.25 2.25 0 00-3.935-2.186zm0-12.814a2.25 2.25 0 103.935-2.186 2.25 2.25 0 00-3.935 2.186z" />
+            </svg>
+            {isCopyingShareLink ? 'Copying...' : 'Share analysis'}
+        </button>
+    </div>
+    <div class="flex flex-col sm:flex-row sm:items-center gap-4">
+        <ModeSelector
+            options={viewModes}
+            label="View by"
+            variant="pill"
+            onChange={(mode) => dispatch('modeChange', { mode })}
+        />
+
+        {#if $modeSelectorStore.selectedMode === 'trust' && !isTrustScope}
+            <div class="flex flex-col gap-4">
+                <div class="flex flex-col items-center gap-2">
+                    <span class="text-sm text-gray-600 leading-tight text-center">
+                        Show percentiles
+                    </span>
+                    <div class="flex items-center gap-2">
+                        <label class="inline-flex items-center {!trustPercentileToggleDisabled ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
+                            <input
+                                type="checkbox"
+                                class="sr-only peer"
+                                checked={$resultsStore.showPercentiles}
+                                disabled={trustPercentileToggleDisabled}
+                                on:change={() => dispatch('percentileToggle')}
+                            />
+                            <div class="relative w-9 h-5 bg-gray-200 peer-focus:outline-none {!trustPercentileToggleDisabled ? 'peer-focus:ring-2 peer-focus:ring-blue-500' : ''} rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-blue-600 {!trustPercentileToggleDisabled ? '' : 'peer-disabled:opacity-50'}"></div>
+                        </label>
+                        <div class="relative inline-block group">
+                            <button type="button" aria-label="Percentiles information" class="text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-oxford-500 flex items-center">
+                                <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                    <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
+                                </svg>
+                            </button>
+                            <div class="absolute z-10 scale-0 transition-all duration-100 origin-top transform
+                                        group-hover:scale-100 w-[280px] -translate-x-1/2 left-1/2 sm:-translate-x-full sm:left-5 top-5 rounded-md shadow-lg bg-white
+                                        ring-1 ring-black ring-opacity-5 p-4">
+                                <p class="text-sm text-gray-500">
+                                    {#if percentilesDisabled}
+                                        Percentiles are disabled when there are fewer than 30 trusts in the filtered cohort. All in-scope trusts are shown individually.
+                                    {:else if $analyseOptions.selectedOrganisations?.length > 0}
+                                        Percentiles show variation in product quantity across NHS Trusts and allow easy comparison of Trust activity relative to the median Trust level. See <a href="/faq/#what-are-percentile-charts" class="underline font-semibold" target="_blank">the FAQs</a> for more details about how to interpret them.
+                                    {:else}
+                                        Percentiles are always shown when no trusts are selected. Select trusts to enable this toggle. See <a href="/faq/#what-are-percentile-charts" class="underline font-semibold" target="_blank">the FAQs</a> for more details.
+                                    {/if}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {/if}
+    </div>
+</div>

--- a/src/components/analyse/results/TotalsTable.svelte
+++ b/src/components/analyse/results/TotalsTable.svelte
@@ -9,7 +9,13 @@
     import { resultsStore } from '../../../stores/resultsStore';
     import { organisationSearchStore } from '../../../stores/organisationSearchStore';
     import { formatNumber } from '../../../utils/utils';
-    import { processTableDataByMode, getModeDisplayName, getTableExplainerText } from '../../../utils/analyseUtils';
+    import { processTableDataByMode } from '../lib/analyseData.js';
+    import {
+        ANALYSIS_SCOPE,
+        getModeDisplayName,
+        getTableExplainerText,
+        formatScopeFilterDescription,
+    } from '../lib/analysisScope.js';
 
     export let data = [];
     export let quantityType = 'SCMD Quantity';
@@ -52,6 +58,12 @@
         }
     }
 
+    $: analysisScope = $resultsStore.scope || ANALYSIS_SCOPE.ALL;
+    $: isFilteredScope = analysisScope === ANALYSIS_SCOPE.GROUP;
+    $: totalsTableOrganisations = Array.isArray($resultsStore.inScopeTrusts)
+        ? $resultsStore.inScopeTrusts
+        : [];
+
     $: groupedData = processTableDataByMode(
         data, 
         selectedMode, 
@@ -59,32 +71,41 @@
         $resultsStore.aggregatedData,
         latestDateFromData,
         $analyseOptions.selectedOrganisations || [],
-        $organisationSearchStore.items || [],
+        totalsTableOrganisations,
         $resultsStore.analysisMonths || [],
-        $organisationSearchStore.regionsHierarchy || []
+        $organisationSearchStore.regionsHierarchy || [],
+        analysisScope
     );
 
     $: titleText = selectedMode === 'national' 
-        ? 'National total' 
-        : `Total quantity by ${getModeDisplayName(selectedMode)}`;
+        ? getModeDisplayName('national', analysisScope)
+        : `Total quantity by ${getModeDisplayName(selectedMode, analysisScope)}`;
 
     $: hasSelectedTrusts = $analyseOptions.selectedOrganisations && $analyseOptions.selectedOrganisations.length > 0;
     
     $: quantityColumnHeader = (() => {
         if (hasSelectedTrusts && selectedMode !== 'trust') {
-            return 'Quantity (selected trusts)';
+            const count = $analyseOptions.selectedOrganisations?.length || 0;
+            return count === 1 ? 'Quantity (selected trust)' : 'Quantity (selected trusts)';
         } else {
             return 'Quantity';
         }
     })();
 
+    $: scopeFilterDescription = isFilteredScope
+        ? formatScopeFilterDescription($resultsStore.scopeFilters || {})
+        : '';
+    $: inScopeTrustCount = totalsTableOrganisations.length;
     $: tableExplainerText = getTableExplainerText(selectedMode, {
         hasSelectedTrusts: hasSelectedTrusts,
         selectedTrustsCount: $analyseOptions.selectedOrganisations?.length || 0,
         selectedPeriod: selectedPeriod,
         latestMonth: latestMonth,
         latestYear: latestYear,
-        dateRange: dateRange
+        dateRange: dateRange,
+        scope: analysisScope,
+        inScopeTrustCount,
+        scopeFilterDescription
     });
 
 </script>

--- a/src/components/common/ModeSelector.svelte
+++ b/src/components/common/ModeSelector.svelte
@@ -2,30 +2,21 @@
   import { modeSelectorStore } from '../../stores/modeSelectorStore.js';
 
   export let options = [];
-  export let initialMode = null;
   export let label = 'Select Mode';
   export let onChange = () => {};
   export let variant = 'dropdown';
 
   const totalTooltipText = 'Monthly quantity across all selected products and NHS Trusts';
 
-  $: {
-    modeSelectorStore.setOptions(options);
-    if (initialMode && !$modeSelectorStore.selectedMode) {
-      modeSelectorStore.setSelectedMode(initialMode);
-    }
-  }
-
-  $: if ($modeSelectorStore.selectedMode !== undefined) {
-    onChange($modeSelectorStore.selectedMode);
-  }
-
   function handleChange(event) {
-    modeSelectorStore.setSelectedMode(event.target.value);
+    const value = event.target.value;
+    modeSelectorStore.setSelectedMode(value);
+    onChange(value);
   }
 
   function handlePillClick(value) {
     modeSelectorStore.setSelectedMode(value);
+    onChange(value);
   }
 </script>
 
@@ -38,7 +29,7 @@
       on:change={handleChange}
       value={$modeSelectorStore.selectedMode}
     >
-      {#each $modeSelectorStore.options as option}
+      {#each options as option (option.value)}
         <option 
           value={option.value}
           title={option.value === 'total' ? totalTooltipText : ''}
@@ -53,7 +44,7 @@
     {#if label}
       <p class="block text-sm font-medium text-gray-700 mb-2">{label}</p>
       <div class="flex flex-wrap gap-2">
-        {#each $modeSelectorStore.options as option}
+        {#each options as option (option.value)}
           <div class="relative inline-block group">
             <button
               class="px-3 py-1 rounded-full text-sm font-medium transition-colors

--- a/src/components/common/OrganisationSearch.svelte
+++ b/src/components/common/OrganisationSearch.svelte
@@ -1,6 +1,15 @@
 <svelte:options customElement={{
     tag: 'organisation-search',
-    shadow: 'none'
+    shadow: 'none',
+    props: {
+      maxItems: { type: 'Number' },
+      hideSelectAll: { type: 'Boolean' },
+      hideClearAll: { type: 'Boolean' },
+      requireSelection: { type: 'Boolean' },
+      overlayMode: { type: 'Boolean' },
+      showTitle: { type: 'Boolean' },
+      disabled: { type: 'Boolean' },
+    }
   }} />
 
 <script>
@@ -14,6 +23,8 @@
     export let disabled = false;
     export let maxItems = null;
     export let hideSelectAll = false;
+    export let hideClearAll = false;
+    export let requireSelection = false;
     export let showTitle = true;
 
     $: placeholderText = disabled ? 
@@ -187,6 +198,13 @@
     };
 
     $: limitReached = maxItems && selectedItems.length >= maxItems;
+  
+    $: selectAllBlockedByCap = maxItems != null && availableItems.length > maxItems;
+    $: shouldHideSelectAll = hideSelectAll || selectAllBlockedByCap;
+    $: hasSelection = selectedItems.some((item) => isItemAvailable(item));
+    $: shouldShowClearAll = !hideClearAll && hasSelection;
+    $: allAvailableSelected = availableItems.length > 0 &&
+        availableItems.every((item) => selectedItems.includes(item));
 
     function toggleItem(item) {
         if (!isItemAvailable(item)) {
@@ -201,6 +219,9 @@
         let newSelectedItems;
 
         if (selectedItems.includes(item)) {
+            if (requireSelection && selectedItems.length <= 1) {
+                return;
+            }
             newSelectedItems = selectedItems.filter((i) => i !== item);
         } else {
             newSelectedItems = [...selectedItems, item];
@@ -216,6 +237,9 @@
     }
 
     function deselectAll() {
+        if (requireSelection) {
+            return;
+        }
         source.updateSelection([]);
         dispatch('selectionChange', {
             selectedItems: [],
@@ -275,7 +299,7 @@
             itemsToSelect: itemsToSelect
         });
         
-        if (!hideSelectAll) {
+        if (!shouldHideSelectAll) {
             source.updateSelection(itemsToSelect);
             dispatch('selectionChange', {
                 selectedItems: itemsToSelect,
@@ -301,8 +325,8 @@
                 {:else}
                     <span></span>
                 {/if}
-                <div class="flex items-center gap-1 text-sm">
-                    {#if !hideSelectAll}
+                <div class="flex items-center gap-1 text-sm min-h-5">
+                    {#if !shouldHideSelectAll && !allAvailableSelected}
                         <button 
                             class="text-blue-600 hover:text-blue-800 font-medium {disabled ? 'opacity-50 cursor-not-allowed' : ''}" 
                             on:click={selectAll}
@@ -310,15 +334,19 @@
                         >
                             Select All
                         </button>
-                        <span class="text-gray-300">|</span>
+                        {#if shouldShowClearAll}
+                            <span class="text-gray-300">|</span>
+                        {/if}
                     {/if}
-                    <button 
-                        class="text-red-600 hover:text-red-800 font-medium {disabled ? 'opacity-50 cursor-not-allowed' : ''}" 
-                        on:click={deselectAll}
-                        disabled={disabled}
-                    >
-                        Clear All
-                    </button>
+                    {#if shouldShowClearAll}
+                        <button 
+                            class="text-red-600 hover:text-red-800 font-medium {disabled ? 'opacity-50 cursor-not-allowed' : ''}" 
+                            on:click={deselectAll}
+                            disabled={disabled}
+                        >
+                            Clear All
+                        </button>
+                    {/if}
                 </div>
             </div>
 

--- a/src/components/common/OrganisationSearchFiltered.svelte
+++ b/src/components/common/OrganisationSearchFiltered.svelte
@@ -7,6 +7,11 @@
     import { onMount, createEventDispatcher } from 'svelte';
     import { get } from 'svelte/store';
     import '../../styles/styles.css';
+    import TrustScopeFilterPanel from './TrustScopeFilterPanel.svelte';
+    import {
+        createEmptyScopeFilters,
+        hasAnyScopeFilters,
+    } from '../../utils/scopeFilters.js';
 
     const dispatch = createEventDispatcher();
 
@@ -54,10 +59,7 @@
         unselectableSectionCollapsed = true;
     }
     $: if (!filterDropdownOpen) {
-        collapsedTrustType = true;
         collapsedRegionIcb = true;
-        collapsedCancerAlliance = true;
-        collapsedShelfordGroup = true;
     }
 
     $: groupedItems = (() => {
@@ -106,11 +108,6 @@
             .replace(/\s+NHS\s+Foundation\s+Trust\s*$/i, '')
             .replace(/\s+NHS\s+Trust\s*$/i, '')
             .trim();
-    }
-
-    function stripNhsPrefix(str) {
-        if (str == null || typeof str !== 'string') return '';
-        return str.replace(/^NHS\s+/i, '').trim();
     }
 
     const INITIALS_STOP_WORDS = new Set(['and']);
@@ -304,57 +301,16 @@
     $: trustTypes = ($source && typeof source.getTrustTypes === 'function' ? source.getTrustTypes() : []) || [];
     $: regionsHierarchy = ($source && typeof source.getRegionsHierarchy === 'function' ? source.getRegionsHierarchy() : []) || [];
     $: cancerAlliances = ($source && typeof source.getCancerAlliances === 'function' ? source.getCancerAlliances() : []) || [];
-    const ACUTE_PREFIX = 'Acute -';
-    $: acuteTypes = trustTypes.filter((t) => t.startsWith(ACUTE_PREFIX));
-    $: otherTypes = trustTypes.filter((t) => !t.startsWith(ACUTE_PREFIX));
-    let filterDropdownOpen = false;
-    let selectedTrustTypes = new Set();
-    let selectedRegions = new Set();
-    let selectedICBs = new Set();
-    let selectedCancerAlliances = new Set();
-    /** null = no filter, 'in' = Shelford only, 'not_in' = non-Shelford only */
-    let shelfordFilter = null;
-    let expandedRegions = new Set();
-    let expandedAcute = false;
-    let collapsedTrustType = true;
-    let collapsedRegionIcb = true;
-    let collapsedCancerAlliance = true;
-    let collapsedShelfordGroup = true;
-    let acuteParentCheckbox;
-    function toggleTrustType(type) {
-        const next = new Set(selectedTrustTypes);
-        if (next.has(type)) next.delete(type); else next.add(type);
-        selectedTrustTypes = next;
-        applyTrustTypeSelection();
-    }
-    function toggleAcuteParent() {
-        const allAcuteSelected = acuteTypes.length > 0 && acuteTypes.every((t) => selectedTrustTypes.has(t));
-        const next = new Set(selectedTrustTypes);
-        if (allAcuteSelected) acuteTypes.forEach((t) => next.delete(t));
-        else acuteTypes.forEach((t) => next.add(t));
-        selectedTrustTypes = next;
-        applyTrustTypeSelection();
-    }
-    $: allAcuteSelected = acuteTypes.length > 0 && acuteTypes.every((t) => selectedTrustTypes.has(t));
-    $: someAcuteSelected = acuteTypes.length > 0 && acuteTypes.some((t) => selectedTrustTypes.has(t));
-    $: acuteIndeterminate = someAcuteSelected && !allAcuteSelected;
-    $: if (acuteParentCheckbox) acuteParentCheckbox.indeterminate = acuteIndeterminate;
-    $: hasSelection = selectedItems.filter((item) => isItemAvailable(item)).length > 0;
-    function clearAllFilters() {
-        selectedTrustTypes = new Set();
-        selectedRegions = new Set();
-        selectedICBs = new Set();
-        selectedCancerAlliances = new Set();
-        shelfordFilter = null;
-        expandedRegions = new Set();
-        applyTrustTypeSelection();
-    }
+    $: hasShelfordData = ($source.orgShelfordGroup || new Map()).size > 0;
 
-    let _lastFilterResetKey;
-    $: if (filterResetKey !== undefined && filterResetKey !== _lastFilterResetKey) {
-        _lastFilterResetKey = filterResetKey;
-        clearAllFilters();
-    }
+    let filterDropdownOpen = false;
+    let selectedRegions = new Set();
+    let collapsedRegionIcb = true;
+    let panelResetKey = 0;
+    let activeScopeFilters = createEmptyScopeFilters();
+
+    $: hasSelection = selectedItems.filter((item) => isItemAvailable(item)).length > 0;
+
     function applyFilterAndSelection(itemList, setAvailableItemsFn) {
         const currentSelected = Array.from(get(source).selectedItems || []);
         if (filterAutoSelectsAll && itemList.length === 0 && currentSelected.length > 0) {
@@ -373,104 +329,76 @@
         }
     }
 
-    function applyTrustTypeSelection() {
+    function applyTrustScopeFilters(filters) {
+        if (typeof source.applyScopeFilters !== 'function') {
+            console.error('Organisation search source must implement applyScopeFilters');
+            return;
+        }
+        const { orgList } = source.applyScopeFilters(filters);
+        applyFilterAndSelection(orgList, null);
+    }
+
+    function handleTrustScopeFiltersChange(event) {
+        activeScopeFilters = event?.detail || createEmptyScopeFilters();
+        applyTrustScopeFilters(activeScopeFilters);
+    }
+
+    function applyIcbRegionSelection() {
+        const store = get(source);
+        const icbList =
+            selectedRegions.size > 0 && typeof source.getICBsByRegions === 'function'
+                ? source.getICBsByRegions(selectedRegions)
+                : Array.from(store.items || []);
+        applyFilterAndSelection(icbList, source.setAvailableItems);
+    }
+
+    function clearAllFilters() {
         const store = get(source);
         if (store.filterType === 'trust') {
-            const allItems = Array.from(store.items || []);
-            let orgList;
-            if (selectedTrustTypes.size > 0 && typeof source.getTrustType === 'function') {
-                orgList = allItems.filter((name) => selectedTrustTypes.has(source.getTrustType(name)));
-            } else {
-                orgList = allItems;
-            }
-            if (selectedRegions.size > 0 || selectedICBs.size > 0 || selectedCancerAlliances.size > 0) {
-                const byRegionIcb = typeof source.getOrgsByRegionsOrICBs === 'function' ? source.getOrgsByRegionsOrICBs(selectedRegions, selectedICBs) : [];
-                const byCancerAlliance = typeof source.getOrgsByCancerAlliances === 'function' ? source.getOrgsByCancerAlliances(selectedCancerAlliances) : [];
-                const combined = new Set([...byRegionIcb, ...byCancerAlliance]);
-                orgList = orgList.filter((name) => combined.has(name));
-            }
-            if (shelfordFilter !== null) {
-                const map = get(source).orgShelfordGroup || new Map();
-                orgList = orgList.filter((name) =>
-                    shelfordFilter === 'in' ? map.get(name) === true : !map.get(name)
-                );
-            }
-            const hasFilters =
-                selectedTrustTypes.size > 0 ||
-                selectedRegions.size > 0 ||
-                selectedICBs.size > 0 ||
-                selectedCancerAlliances.size > 0 ||
-                shelfordFilter !== null;
-            if (typeof source.setFiltersApplied === 'function') source.setFiltersApplied(hasFilters);
-            applyFilterAndSelection(orgList, source.setAvailableItems);
-        } else if (store.filterType === 'icb') {
-            const icbList = selectedRegions.size > 0 && typeof source.getICBsByRegions === 'function' ? source.getICBsByRegions(selectedRegions) : Array.from(store.items || []);
-            applyFilterAndSelection(icbList, source.setAvailableItems);
+            panelResetKey += 1;
+            activeScopeFilters = createEmptyScopeFilters();
+            if (typeof source.setFiltersApplied === 'function') source.setFiltersApplied(false);
+            applyFilterAndSelection(Array.from(store.items || []), source.setAvailableItems);
+            return;
         }
+        selectedRegions = new Set();
+        applyIcbRegionSelection();
     }
-    function toggleRegionExpansion(regionName) {
-        const next = new Set(expandedRegions);
-        if (next.has(regionName)) next.delete(regionName); else next.add(regionName);
-        expandedRegions = next;
+
+    let _lastFilterResetKey;
+    $: if (filterResetKey !== undefined && filterResetKey !== _lastFilterResetKey) {
+        _lastFilterResetKey = filterResetKey;
+        clearAllFilters();
     }
+
     function toggleRegion(regionName) {
         const nextR = new Set(selectedRegions);
-        const nextI = new Set(selectedICBs);
         if (nextR.has(regionName)) nextR.delete(regionName);
-        else {
-            nextR.add(regionName);
-            const regionData = regionsHierarchy.find((r) => r.region === regionName);
-            if (regionData) (regionData.icbs || []).forEach((icb) => nextI.delete(icb.name));
-        }
+        else nextR.add(regionName);
         selectedRegions = nextR;
-        selectedICBs = nextI;
-        applyTrustTypeSelection();
+        applyIcbRegionSelection();
     }
-    function toggleICB(icbName) {
-        if (selectedRegions.size > 0) return;
-        const next = new Set(selectedICBs);
-        if (next.has(icbName)) next.delete(icbName);
-        else next.add(icbName);
-        selectedICBs = next;
-        applyTrustTypeSelection();
-    }
-    function toggleCancerAlliance(caName) {
-        const next = new Set(selectedCancerAlliances);
-        if (next.has(caName)) next.delete(caName);
-        else next.add(caName);
-        selectedCancerAlliances = next;
-        applyTrustTypeSelection();
-    }
-    function toggleShelford(key) {
-        shelfordFilter = shelfordFilter === key ? null : key;
-        applyTrustTypeSelection();
-    }
-    $: hasShelfordData = ($source.orgShelfordGroup || new Map()).size > 0;
-    $: shelfordInCount = ($source.items || []).filter(
-        (n) => ($source.orgShelfordGroup || new Map()).get(n) === true
-    ).length;
-    $: shelfordNotCount = ($source.items || []).filter(
-        (n) => !($source.orgShelfordGroup || new Map()).get(n)
-    ).length;
+
     $: filterBadgeCount =
-        selectedTrustTypes.size +
-        selectedRegions.size +
-        selectedICBs.size +
-        selectedCancerAlliances.size +
-        (shelfordFilter !== null ? 1 : 0);
+        $source.filterType === 'trust'
+            ? (activeScopeFilters.trustTypes?.length || 0) +
+              (activeScopeFilters.regions?.length || 0) +
+              (activeScopeFilters.icbs?.length || 0) +
+              (activeScopeFilters.cancerAlliances?.length || 0) +
+              (activeScopeFilters.shelford !== null ? 1 : 0)
+            : selectedRegions.size;
     $: hasFilterSelection =
-        selectedTrustTypes.size > 0 ||
-        selectedRegions.size > 0 ||
-        selectedICBs.size > 0 ||
-        selectedCancerAlliances.size > 0 ||
-        shelfordFilter !== null;
+        $source.filterType === 'trust'
+            ? hasAnyScopeFilters(activeScopeFilters)
+            : selectedRegions.size > 0;
     $: hasFilters =
         showFilters &&
-        $source.filterType === 'trust' &&
-        (trustTypes.length > 0 ||
-            regionsHierarchy.length > 0 ||
-            cancerAlliances.length > 0 ||
-            hasShelfordData);
+        (($source.filterType === 'trust' &&
+            (trustTypes.length > 0 ||
+                regionsHierarchy.length > 0 ||
+                cancerAlliances.length > 0 ||
+                hasShelfordData)) ||
+            ($source.filterType === 'icb' && regionsHierarchy.length > 0));
     $: selectedAvailableCount = selectedItems.filter((item) => isItemAvailable(item)).length;
     $: totalAvailable = Array.from($source.availableItems || []).length;
     $: allSelected = totalAvailable > 0 && selectedAvailableCount >= totalAvailable;
@@ -529,6 +457,17 @@
             <div class="relative {hasFilters ? (subtitle ? 'mt-1' : 'mt-2') : ''} min-w-0 {hasFilters && filterDropdownOpen && !overlayMode ? 'min-h-[min(70vh,400px)]' : ''}">
                 {#if hasFilters && filterDropdownOpen}
                 <div class="absolute top-0 left-0 right-0 {overlayMode ? 'z-[1000]' : 'z-10'} w-full min-w-[200px] max-w-full sm:min-w-[240px] max-h-[min(70vh,400px)] flex flex-col rounded-lg border border-gray-200 bg-white shadow-lg overflow-hidden" role="listbox">
+                {#if $source.filterType === 'trust'}
+                    <div class="flex-1 min-h-0 overflow-hidden [&_>div]:border-0 [&_>div]:rounded-none">
+                        <TrustScopeFilterPanel
+                            source={source}
+                            applyAvailability={false}
+                            resetKey={panelResetKey}
+                            initialFilters={activeScopeFilters}
+                            on:filtersChange={handleTrustScopeFiltersChange}
+                        />
+                    </div>
+                {:else if $source.filterType === 'icb'}
                 <div class="flex-1 overflow-y-auto py-2">
                     <div class="px-3 pb-2 mb-2 border-b border-gray-100 flex items-center justify-between">
                         <span class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Filter by</span>
@@ -536,98 +475,25 @@
                         <button type="button" class="text-xs font-medium text-oxford-600 hover:text-oxford-800 py-0.5 px-1.5 rounded hover:bg-oxford-50 transition-colors" on:click={clearAllFilters}>Clear all</button>
                         {/if}
                     </div>
-                    {#if $source.filterType === 'trust' && trustTypes.length > 0}
-                    <div class="px-2 pb-2">
-                        <button type="button" class="w-full flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-gray-500 uppercase tracking-wide mb-1 hover:bg-gray-50 transition-colors" on:click={() => collapsedTrustType = !collapsedTrustType}>
-                            <span>Trust type</span>
-                            <svg class="w-3.5 h-3.5 transition-transform duration-200 {collapsedTrustType ? '' : 'rotate-180'}" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
-                        </button>
-                        {#if !collapsedTrustType}
-                        {#if acuteTypes.length > 0}
-                        <div class="px-2 pt-1 pb-0.5">
-                            <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium text-gray-800 hover:bg-gray-50 transition-colors">
-                                <button type="button" class="p-1 -m-1 hover:bg-gray-200/60 rounded-md transition-colors shrink-0 text-gray-400" on:click={() => expandedAcute = !expandedAcute} aria-label={expandedAcute ? 'Collapse' : 'Expand'}><svg class="w-3.5 h-3.5 transition-transform duration-200 {expandedAcute ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg></button>
-                                <label class="flex items-center gap-2.5 cursor-pointer flex-1 min-w-0"><input bind:this={acuteParentCheckbox} type="checkbox" checked={allAcuteSelected} on:change={toggleAcuteParent} class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0" /><span>Acute</span></label>
-                                <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">{acuteTypes.reduce((n, t) => n + (source.getOrgsByTrustTypeGlobal?.(t) || []).length, 0)} trusts</span>
-                            </div>
-                            {#if expandedAcute}
-                            <div class="ml-6 pl-3 mt-0.5 border-l-2 border-gray-200 space-y-0.5">
-                                {#each acuteTypes as type}<label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-1 text-sm text-gray-600 transition-colors"><input type="checkbox" checked={selectedTrustTypes.has(type)} on:change={() => toggleTrustType(type)} class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0" /><span>{type.replace(ACUTE_PREFIX, '').trim()}</span><span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded ml-auto">{(source.getOrgsByTrustTypeGlobal?.(type) || []).length} trusts</span></label>{/each}
-                            </div>
-                            {/if}
-                        </div>
-                        {/if}
-                        {#each otherTypes as type}<label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0"><input type="checkbox" checked={selectedTrustTypes.has(type)} on:change={() => toggleTrustType(type)} class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0" /><span class="flex-1 min-w-0">{type}</span><span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">{(source.getOrgsByTrustTypeGlobal?.(type) || []).length} trusts</span></label>{/each}
-                        {/if}
-                    </div>
-                    {/if}
                     {#if regionsHierarchy.length > 0}
-                    <div class="px-2 pt-2 {$source.filterType === 'trust' && trustTypes.length > 0 ? 'border-t border-gray-100' : ''}">
+                    <div class="px-2 pt-2">
                         <button type="button" class="w-full flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-gray-500 uppercase tracking-wide mb-1 hover:bg-gray-50 transition-colors" on:click={() => collapsedRegionIcb = !collapsedRegionIcb}>
-                            <span>{$source.filterType === 'icb' ? 'Region' : 'Region & ICB'}</span>
+                            <span>Region</span>
                             <svg class="w-3.5 h-3.5 transition-transform duration-200 {collapsedRegionIcb ? '' : 'rotate-180'}" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
                         </button>
                         {#if !collapsedRegionIcb}
-                        {#each regionsHierarchy as region}
+                        {#each regionsHierarchy as region (region.region)}
                         <div class="px-1">
                             <div class="flex items-center gap-2 rounded-lg px-2 py-2 sm:py-1.5 text-sm hover:bg-gray-50 transition-colors min-h-[44px] sm:min-h-0 {selectedRegions.has(region.region) ? 'text-oxford-700' : 'text-gray-700'}">
-                                {#if $source.filterType === 'trust'}<button type="button" class="p-1.5 -m-1 hover:bg-gray-200/60 rounded-md transition-colors shrink-0 text-gray-400" on:click={() => toggleRegionExpansion(region.region)} aria-label={expandedRegions.has(region.region) ? 'Collapse' : 'Expand'}><svg class="w-3.5 h-3.5 transition-transform duration-200 {expandedRegions.has(region.region) ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg></button>{/if}
                                 <label class="flex items-center gap-2.5 cursor-pointer flex-1 min-w-0"><input type="checkbox" checked={selectedRegions.has(region.region)} on:change={() => toggleRegion(region.region)} class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0" /><span class="truncate" title={region.region + (region.region_code ? ' (' + region.region_code + ')' : '')}>{region.region}{#if region.region_code}&nbsp;({region.region_code}){/if}</span></label>
-                                {#if $source.filterType === 'trust'}<span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">{(region.icbs || []).length} ICBs · {(source.getOrgsByRegion?.(region.region) || []).length} trusts</span>{/if}
                             </div>
-                            {#if expandedRegions.has(region.region) && $source.filterType === 'trust'}
-                            <div class="ml-6 pl-3 mt-0.5 border-l-2 border-gray-200 space-y-0.5">
-                                {#each (region.icbs || []) as icb}<label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-1 text-sm transition-colors {selectedRegions.has(region.region) ? 'opacity-50' : ''} {selectedICBs.has(icb.name) ? 'text-oxford-700' : 'text-gray-600'}"><input type="checkbox" checked={selectedICBs.has(icb.name) || selectedRegions.has(region.region)} disabled={selectedRegions.has(region.region)} on:change={() => toggleICB(icb.name)} class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0" /><span class="truncate flex-1 min-w-0" title={icb.name + (icb.code ? ' (' + icb.code + ')' : '')}>{stripNhsPrefix(icb.name)}{#if icb.code}&nbsp;({icb.code}){/if}</span><span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">{(source.getOrgsByICB?.(icb.name) || []).length} trusts</span></label>{/each}
-                            </div>
-                            {/if}
                         </div>
                         {/each}
-                        {/if}
-                    </div>
-                    {/if}
-                    {#if cancerAlliances.length > 0}
-                    <div class="px-2 pt-2 {$source.filterType === 'trust' && (trustTypes.length > 0 || regionsHierarchy.length > 0) ? 'border-t border-gray-100' : ''}">
-                        <button type="button" class="w-full flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-gray-500 uppercase tracking-wide mb-1 hover:bg-gray-50 transition-colors" on:click={() => collapsedCancerAlliance = !collapsedCancerAlliance}>
-                            <span>Cancer Alliance</span>
-                            <svg class="w-3.5 h-3.5 transition-transform duration-200 {collapsedCancerAlliance ? '' : 'rotate-180'}" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
-                        </button>
-                        {#if !collapsedCancerAlliance}
-                        {#each cancerAlliances as ca}
-                        <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 {selectedCancerAlliances.has(ca.name) ? 'text-oxford-700' : ''}">
-                            <input type="checkbox" checked={selectedCancerAlliances.has(ca.name)} on:change={() => toggleCancerAlliance(ca.name)} class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0" />
-                            <span class="truncate flex-1 min-w-0" title={ca.name}>{ca.name}</span>
-                            <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">{(source.getOrgsByCancerAlliance?.(ca.name) || []).length} trusts</span>
-                        </label>
-                        {/each}
-                        <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 border-t border-gray-100 mt-1 pt-1.5 {selectedCancerAlliances.has('Not applicable') ? 'text-oxford-700' : ''}">
-                            <input type="checkbox" checked={selectedCancerAlliances.has('Not applicable')} on:change={() => toggleCancerAlliance('Not applicable')} class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0" />
-                            <span class="truncate flex-1 min-w-0" title="Trusts not associated with a Cancer Alliance">Not applicable</span>
-                            <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">{(source.getOrgsWithNoCancerAlliance?.() || []).length} trusts</span>
-                        </label>
-                        {/if}
-                    </div>
-                    {/if}
-                    {#if $source.filterType === 'trust' && hasShelfordData}
-                    <div class="px-2 pt-2 {$source.filterType === 'trust' && (trustTypes.length > 0 || regionsHierarchy.length > 0 || cancerAlliances.length > 0) ? 'border-t border-gray-100' : ''}">
-                        <button type="button" class="w-full flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-gray-500 uppercase tracking-wide mb-1 hover:bg-gray-50 transition-colors" on:click={() => collapsedShelfordGroup = !collapsedShelfordGroup}>
-                            <span>Shelford Group</span>
-                            <svg class="w-3.5 h-3.5 transition-transform duration-200 {collapsedShelfordGroup ? '' : 'rotate-180'}" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
-                        </button>
-                        {#if !collapsedShelfordGroup}
-                        <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 {shelfordFilter === 'in' ? 'text-oxford-700' : ''}">
-                            <input type="checkbox" checked={shelfordFilter === 'in'} on:change={() => toggleShelford('in')} class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0" />
-                            <span class="truncate flex-1 min-w-0" title="Trusts in the Shelford Group">In Shelford Group</span>
-                            <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">{shelfordInCount} trusts</span>
-                        </label>
-                        <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 {shelfordFilter === 'not_in' ? 'text-oxford-700' : ''}">
-                            <input type="checkbox" checked={shelfordFilter === 'not_in'} on:change={() => toggleShelford('not_in')} class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0" />
-                            <span class="truncate flex-1 min-w-0" title="Trusts not in the Shelford Group">Not in Shelford Group</span>
-                            <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">{shelfordNotCount} trusts</span>
-                        </label>
                         {/if}
                     </div>
                     {/if}
                 </div>
+                {/if}
                 <div class="py-2 px-3 border-t border-gray-200 flex justify-end bg-gray-50 shrink-0">
                     <button
                         type="button"

--- a/src/components/common/TrustScopeFilterPanel.svelte
+++ b/src/components/common/TrustScopeFilterPanel.svelte
@@ -1,0 +1,506 @@
+<script>
+    import { createEventDispatcher, onMount } from 'svelte';
+    import {
+        ACUTE_PARENT,
+        acuteSubtypeLabel,
+        CANCER_ALLIANCE_NA,
+        cancerAllianceDisplayName,
+        hasAnyScopeFilters,
+        isAcuteType,
+        normaliseAcuteSelection as normaliseAcuteSelectionSet,
+    } from '../../utils/scopeFilters.js';
+    import { updateRegionSelection, updateIcbSelection } from '../../utils/regionIcbFilterUtils.js';
+
+    const dispatch = createEventDispatcher();
+
+    export let source;
+    export let initialFilters = null;
+    export let applyAvailability = true;
+    export let resetKey = undefined;
+
+    function normaliseAcuteSelection(types) {
+        return normaliseAcuteSelectionSet(types, acuteTypes, { asArray: true });
+    }
+
+    $: trustTypes = ($source ? source.getTrustTypes() : []) || [];
+    $: regionsHierarchy = ($source ? source.getRegionsHierarchy() : []) || [];
+    $: cancerAlliances = ($source ? source.getCancerAlliances() : []) || [];
+    $: hasShelfordData = ($source.orgShelfordGroup || new Map()).size > 0;
+
+    $: acuteTypes = trustTypes.filter((type) => isAcuteType(type));
+    $: otherTypes = trustTypes.filter((type) => !isAcuteType(type));
+
+    let selectedTrustTypes = [];
+    let selectedRegions = new Set();
+    let selectedICBs = new Set();
+    let selectedCancerAlliances = new Set();
+    let shelfordFilter = null;
+    let expandedRegions = new Set();
+    let expandedAcute = false;
+
+    let collapsedTrustType = true;
+    let collapsedRegionIcb = true;
+    let collapsedCancerAlliance = true;
+    let collapsedShelfordGroup = true;
+
+    $: acuteParentSelected = selectedTrustTypes.includes(ACUTE_PARENT);
+    $: selectedAcuteSubtypeCount = selectedTrustTypes.filter(isAcuteType).length;
+    $: acuteIndeterminate = !acuteParentSelected && selectedAcuteSubtypeCount > 0;
+
+    $: shelfordInCount = ($source.items || []).filter(
+        (name) => ($source.orgShelfordGroup || new Map()).get(name) === true
+    ).length;
+    $: shelfordNotCount = ($source.items || []).filter(
+        (name) => !($source.orgShelfordGroup || new Map()).get(name)
+    ).length;
+
+    $: selectedOtherTrustTypeCount = selectedTrustTypes.filter(
+        (type) => type !== ACUTE_PARENT && !isAcuteType(type)
+    ).length;
+    $: selectedTrustTypeFilterCount =
+        selectedOtherTrustTypeCount + (acuteParentSelected ? 1 : selectedAcuteSubtypeCount);
+    $: filterBadgeCount =
+        selectedTrustTypeFilterCount +
+        selectedRegions.size +
+        selectedICBs.size +
+        selectedCancerAlliances.size +
+        (shelfordFilter !== null ? 1 : 0);
+
+    function stripNhsPrefix(str) {
+        if (str == null || typeof str !== 'string') return '';
+        return str.replace(/^NHS\s+/i, '').trim();
+    }
+
+    function getCurrentFilters() {
+        return {
+            trustTypes: [...selectedTrustTypes].sort(),
+            regions: Array.from(selectedRegions).sort(),
+            icbs: Array.from(selectedICBs).sort(),
+            cancerAlliances: Array.from(selectedCancerAlliances).sort(),
+            shelford: shelfordFilter
+        };
+    }
+
+    function emitFiltersChange() {
+        dispatch('filtersChange', getCurrentFilters());
+    }
+
+    function applyFilters(filters) {
+        selectedTrustTypes = normaliseAcuteSelection(
+            Array.isArray(filters?.trustTypes) ? filters.trustTypes : []
+        );
+        selectedRegions = new Set(Array.isArray(filters?.regions) ? filters.regions : []);
+        selectedICBs = new Set(Array.isArray(filters?.icbs) ? filters.icbs : []);
+        selectedCancerAlliances = new Set(Array.isArray(filters?.cancerAlliances) ? filters.cancerAlliances : []);
+        shelfordFilter = filters?.shelford === 'in' || filters?.shelford === 'not_in' ? filters.shelford : null;
+        if (selectedTrustTypes.length > 0) collapsedTrustType = false;
+        if (selectedTrustTypes.some(isAcuteType) || selectedTrustTypes.includes(ACUTE_PARENT)) {
+            expandedAcute = true;
+        }
+        if (selectedRegions.size > 0 || selectedICBs.size > 0) collapsedRegionIcb = false;
+        if (selectedCancerAlliances.size > 0) collapsedCancerAlliance = false;
+        if (shelfordFilter !== null) collapsedShelfordGroup = false;
+        applyTrustTypeSelection();
+    }
+
+    onMount(() => {
+        if (hasAnyScopeFilters(initialFilters)) {
+            applyFilters(initialFilters);
+        }
+    });
+
+    let _lastResetKey = resetKey;
+    $: if (resetKey !== undefined && resetKey !== _lastResetKey) {
+        _lastResetKey = resetKey;
+        clearAllFilters();
+    }
+
+    function applyTrustTypeSelection() {
+        if (!applyAvailability) return;
+        if (typeof source.applyScopeFilters !== 'function') {
+            console.error('Trust scope filter source must implement applyScopeFilters');
+            return;
+        }
+        source.applyScopeFilters(getCurrentFilters());
+    }
+
+    function toggleTrustType(type) {
+        if (isAcuteType(type) && selectedTrustTypes.includes(ACUTE_PARENT)) return;
+        const next = new Set(selectedTrustTypes);
+        if (next.has(type)) next.delete(type);
+        else next.add(type);
+        selectedTrustTypes = normaliseAcuteSelection(Array.from(next));
+        emitFiltersChange();
+        applyTrustTypeSelection();
+    }
+
+    function toggleAcuteParent() {
+        const next = new Set(selectedTrustTypes);
+        if (next.has(ACUTE_PARENT)) {
+            next.delete(ACUTE_PARENT);
+        } else {
+            next.add(ACUTE_PARENT);
+            acuteTypes.forEach((type) => next.delete(type));
+        }
+        selectedTrustTypes = Array.from(next).sort();
+        emitFiltersChange();
+        applyTrustTypeSelection();
+    }
+
+    function toggleRegionExpansion(regionName) {
+        const next = new Set(expandedRegions);
+        if (next.has(regionName)) next.delete(regionName);
+        else next.add(regionName);
+        expandedRegions = next;
+    }
+
+    function toggleRegion(regionName) {
+        const regionData = regionsHierarchy.find((region) => region.region === regionName) || {
+            region: regionName,
+            icbs: []
+        };
+        const updated = updateRegionSelection(regionData, selectedRegions, selectedICBs);
+        selectedRegions = updated.selectedRegions;
+        selectedICBs = updated.selectedICBs;
+        emitFiltersChange();
+        applyTrustTypeSelection();
+    }
+
+    function toggleICB(icbName) {
+        const parentRegion = regionsHierarchy.find((region) =>
+            (region.icbs || []).some((icb) => icb.name === icbName)
+        );
+        if (parentRegion) {
+            const updated = updateIcbSelection(
+                parentRegion,
+                { name: icbName },
+                selectedRegions,
+                selectedICBs
+            );
+            if (!updated) return;
+            selectedRegions = updated.selectedRegions;
+            selectedICBs = updated.selectedICBs;
+        } else {
+            const next = new Set(selectedICBs);
+            if (next.has(icbName)) next.delete(icbName);
+            else next.add(icbName);
+            selectedICBs = next;
+        }
+        emitFiltersChange();
+        applyTrustTypeSelection();
+    }
+
+    function toggleCancerAlliance(caName) {
+        const next = new Set(selectedCancerAlliances);
+        if (next.has(caName)) next.delete(caName);
+        else next.add(caName);
+        selectedCancerAlliances = next;
+        emitFiltersChange();
+        applyTrustTypeSelection();
+    }
+
+    function toggleShelford(filterValue) {
+        shelfordFilter = shelfordFilter === filterValue ? null : filterValue;
+        emitFiltersChange();
+        applyTrustTypeSelection();
+    }
+
+    function clearAllFilters() {
+        selectedTrustTypes = [];
+        selectedRegions = new Set();
+        selectedICBs = new Set();
+        selectedCancerAlliances = new Set();
+        shelfordFilter = null;
+        expandedRegions = new Set();
+        emitFiltersChange();
+        applyTrustTypeSelection();
+    }
+</script>
+
+<div class="w-full flex flex-col rounded-lg border border-gray-200 bg-white overflow-hidden">
+    <div class="px-3 py-2 border-b border-gray-100 flex items-center justify-between shrink-0">
+        <div class="flex items-center gap-1.5 min-w-0">
+            <span class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Filter by</span>
+            {#if filterBadgeCount > 0}
+                <span class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded-full text-[10px] font-medium leading-none bg-oxford-100 text-oxford-700">{filterBadgeCount}</span>
+            {/if}
+        </div>
+        {#if filterBadgeCount > 0}
+            <button
+                type="button"
+                class="text-xs font-medium text-oxford-600 hover:text-oxford-800 py-0.5 px-1.5 rounded hover:bg-oxford-50 transition-colors"
+                on:click={clearAllFilters}
+            >
+                Clear all
+            </button>
+        {/if}
+    </div>
+    <div class="flex-1 overflow-y-auto py-2 max-h-[min(70vh,400px)]">
+        {#if trustTypes.length > 0}
+            <div class="px-2 pb-2">
+                <button
+                    type="button"
+                    class="w-full flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-gray-500 uppercase tracking-wide mb-1 hover:bg-gray-50 transition-colors"
+                    on:click={() => (collapsedTrustType = !collapsedTrustType)}
+                >
+                    <span>Trust type</span>
+                    <svg
+                        class="w-3.5 h-3.5 transition-transform duration-200 {collapsedTrustType ? '' : 'rotate-180'}"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                    >
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                    </svg>
+                </button>
+                {#if !collapsedTrustType}
+                    {#if acuteTypes.length > 0}
+                        <div class="px-2 pt-1 pb-0.5">
+                            <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium hover:bg-gray-50 transition-colors {selectedTrustTypes.includes(ACUTE_PARENT) ? 'text-oxford-700' : 'text-gray-800'}">
+                                <button
+                                    type="button"
+                                    class="p-1 -m-1 hover:bg-gray-200/60 rounded-md transition-colors shrink-0 text-gray-400"
+                                    on:click={() => (expandedAcute = !expandedAcute)}
+                                    aria-label={expandedAcute ? 'Collapse' : 'Expand'}
+                                >
+                                    <svg
+                                        class="w-3.5 h-3.5 transition-transform duration-200 {expandedAcute ? 'rotate-90' : ''}"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        viewBox="0 0 24 24"
+                                    >
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                                    </svg>
+                                </button>
+                                <label class="flex items-center gap-2.5 cursor-pointer flex-1 min-w-0">
+                                    <input
+                                        type="checkbox"
+                                        checked={acuteParentSelected}
+                                        indeterminate={acuteIndeterminate}
+                                        on:change={toggleAcuteParent}
+                                        class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0"
+                                    />
+                                    <span>Acute</span>
+                                </label>
+                                <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
+                                    {acuteTypes.reduce((n, t) => n + (source.getOrgsByTrustTypeGlobal(t) || []).length, 0)} trusts
+                                </span>
+                            </div>
+                            {#if expandedAcute}
+                                <div class="ml-6 pl-3 mt-0.5 border-l-2 border-gray-200 space-y-0.5">
+                                    {#each acuteTypes as type (type)}
+                                        <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-1 text-sm transition-colors {selectedTrustTypes.includes(ACUTE_PARENT) ? 'opacity-50' : ''} {selectedTrustTypes.includes(ACUTE_PARENT) || selectedTrustTypes.includes(type) ? 'text-oxford-700' : 'text-gray-600'}">
+                                            <input
+                                                type="checkbox"
+                                                checked={selectedTrustTypes.includes(ACUTE_PARENT) || selectedTrustTypes.includes(type)}
+                                                on:change={() => toggleTrustType(type)}
+                                                class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0"
+                                                disabled={selectedTrustTypes.includes(ACUTE_PARENT)}
+                                            />
+                                            <span>{acuteSubtypeLabel(type)}</span>
+                                            <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded ml-auto">
+                                                {(source.getOrgsByTrustTypeGlobal(type) || []).length} trusts
+                                            </span>
+                                        </label>
+                                    {/each}
+                                </div>
+                            {/if}
+                        </div>
+                    {/if}
+                    {#each otherTypes as type (type)}
+                        <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0">
+                            <input
+                                type="checkbox"
+                                checked={selectedTrustTypes.includes(type)}
+                                on:change={() => toggleTrustType(type)}
+                                class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
+                            />
+                            <span class="flex-1 min-w-0">{type}</span>
+                            <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
+                                {(source.getOrgsByTrustTypeGlobal(type) || []).length} trusts
+                            </span>
+                        </label>
+                    {/each}
+                {/if}
+            </div>
+        {/if}
+
+        {#if regionsHierarchy.length > 0}
+            <div class="px-2 pt-2 {trustTypes.length > 0 ? 'border-t border-gray-100' : ''}">
+                <button
+                    type="button"
+                    class="w-full flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-gray-500 uppercase tracking-wide mb-1 hover:bg-gray-50 transition-colors"
+                    on:click={() => (collapsedRegionIcb = !collapsedRegionIcb)}
+                >
+                    <span>Region &amp; ICB</span>
+                    <svg
+                        class="w-3.5 h-3.5 transition-transform duration-200 {collapsedRegionIcb ? '' : 'rotate-180'}"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                    >
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                    </svg>
+                </button>
+                {#if !collapsedRegionIcb}
+                    {#each regionsHierarchy as region (region.region)}
+                        <div class="px-1">
+                            <div class="flex flex-wrap items-start gap-2 rounded-lg px-2 py-2 sm:py-1.5 text-sm hover:bg-gray-50 transition-colors min-h-[44px] sm:min-h-0 min-w-0 w-full {selectedRegions.has(region.region) ? 'text-oxford-700' : 'text-gray-700'}">
+                                <button
+                                    type="button"
+                                    class="p-1.5 -m-1 hover:bg-gray-200/60 rounded-md transition-colors shrink-0 text-gray-400"
+                                    on:click={() => toggleRegionExpansion(region.region)}
+                                    aria-label={expandedRegions.has(region.region) ? 'Collapse' : 'Expand'}
+                                >
+                                    <svg
+                                        class="w-3.5 h-3.5 transition-transform duration-200 {expandedRegions.has(region.region) ? 'rotate-90' : ''}"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        viewBox="0 0 24 24"
+                                    >
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                                    </svg>
+                                </button>
+                                <label class="flex items-start gap-2.5 cursor-pointer flex-1 min-w-0">
+                                    <input
+                                        type="checkbox"
+                                        checked={selectedRegions.has(region.region)}
+                                        on:change={() => toggleRegion(region.region)}
+                                        class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
+                                    />
+                                    <span
+                                        class="flex-1 min-w-0 break-words"
+                                        title={region.region + (region.region_code ? ' (' + region.region_code + ')' : '')}
+                                    >
+                                        {region.region}{#if region.region_code}<span class="whitespace-nowrap">&nbsp;({region.region_code})</span>{/if}
+                                    </span>
+                                </label>
+                                <span class="text-[10px] font-medium text-gray-400 whitespace-normal text-right tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
+                                    {(region.icbs || []).length} ICBs · {(source.getOrgsByRegion(region.region) || []).length} trusts
+                                </span>
+                            </div>
+                            {#if expandedRegions.has(region.region)}
+                                <div class="ml-6 pl-3 mt-0.5 border-l-2 border-gray-200 space-y-0.5">
+                                    {#each region.icbs || [] as icb (icb.name)}
+                                        <label class="flex flex-wrap w-full items-start gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-1 text-sm transition-colors min-w-0 {selectedRegions.has(region.region) ? 'opacity-50' : ''} {selectedICBs.has(icb.name) ? 'text-oxford-700' : 'text-gray-600'}">
+                                            <input
+                                                type="checkbox"
+                                                checked={selectedICBs.has(icb.name) || selectedRegions.has(region.region)}
+                                                disabled={selectedRegions.has(region.region)}
+                                                on:change={() => toggleICB(icb.name)}
+                                                class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0"
+                                            />
+                                            <span
+                                                class="flex-1 min-w-0 break-words"
+                                                title={icb.name + (icb.code ? ' (' + icb.code + ')' : '')}
+                                            >
+                                                {stripNhsPrefix(icb.name)}{#if icb.code}<span class="whitespace-nowrap">&nbsp;({icb.code})</span>{/if}
+                                            </span>
+                                            <span class="text-[10px] font-medium text-gray-400 whitespace-normal text-right tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
+                                                {(source.getOrgsByICB(icb.name) || []).length} trusts
+                                            </span>
+                                        </label>
+                                    {/each}
+                                </div>
+                            {/if}
+                        </div>
+                    {/each}
+                {/if}
+            </div>
+        {/if}
+
+        {#if cancerAlliances.length > 0}
+            <div class="px-2 pt-2 {trustTypes.length > 0 || regionsHierarchy.length > 0 ? 'border-t border-gray-100' : ''}">
+                <button
+                    type="button"
+                    class="w-full flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-gray-500 uppercase tracking-wide mb-1 hover:bg-gray-50 transition-colors"
+                    on:click={() => (collapsedCancerAlliance = !collapsedCancerAlliance)}
+                >
+                    <span>Cancer Alliance</span>
+                    <svg
+                        class="w-3.5 h-3.5 transition-transform duration-200 {collapsedCancerAlliance ? '' : 'rotate-180'}"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                    >
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                    </svg>
+                </button>
+                {#if !collapsedCancerAlliance}
+                    {#each cancerAlliances as ca (ca.name)}
+                        <label class="flex flex-wrap items-start gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 min-w-0 w-full {selectedCancerAlliances.has(ca.name) ? 'text-oxford-700' : ''}">
+                            <input
+                                type="checkbox"
+                                checked={selectedCancerAlliances.has(ca.name)}
+                                on:change={() => toggleCancerAlliance(ca.name)}
+                                class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
+                            />
+                            <span class="flex-1 min-w-0 break-words" title={ca.name}>{cancerAllianceDisplayName(ca.name)}</span>
+                            <span class="text-[10px] font-medium text-gray-400 whitespace-normal text-right tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
+                                {(source.getOrgsByCancerAlliance(ca.name) || []).length} trusts
+                            </span>
+                        </label>
+                    {/each}
+                    <label class="flex flex-wrap items-start gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 border-t border-gray-100 mt-1 pt-1.5 min-w-0 w-full {selectedCancerAlliances.has(CANCER_ALLIANCE_NA) ? 'text-oxford-700' : ''}">
+                        <input
+                            type="checkbox"
+                            checked={selectedCancerAlliances.has(CANCER_ALLIANCE_NA)}
+                            on:change={() => toggleCancerAlliance(CANCER_ALLIANCE_NA)}
+                            class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
+                        />
+                        <span class="flex-1 min-w-0 break-words" title="Trusts not associated with a Cancer Alliance">{cancerAllianceDisplayName(CANCER_ALLIANCE_NA)}</span>
+                        <span class="text-[10px] font-medium text-gray-400 whitespace-normal text-right tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
+                            {(source.getOrgsWithNoCancerAlliance() || []).length} trusts
+                        </span>
+                    </label>
+                {/if}
+            </div>
+        {/if}
+
+        {#if hasShelfordData}
+            <div class="px-2 pt-2 {trustTypes.length > 0 || regionsHierarchy.length > 0 || cancerAlliances.length > 0 ? 'border-t border-gray-100' : ''}">
+                <button
+                    type="button"
+                    class="w-full flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-gray-500 uppercase tracking-wide mb-1 hover:bg-gray-50 transition-colors"
+                    on:click={() => (collapsedShelfordGroup = !collapsedShelfordGroup)}
+                >
+                    <span>Shelford Group</span>
+                    <svg
+                        class="w-3.5 h-3.5 transition-transform duration-200 {collapsedShelfordGroup ? '' : 'rotate-180'}"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                    >
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                    </svg>
+                </button>
+                {#if !collapsedShelfordGroup}
+                    <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 {shelfordFilter === 'in' ? 'text-oxford-700' : ''}">
+                        <input
+                            type="checkbox"
+                            checked={shelfordFilter === 'in'}
+                            on:change={() => toggleShelford('in')}
+                            class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
+                        />
+                        <span class="truncate flex-1 min-w-0" title="Trusts in the Shelford Group">In Shelford Group</span>
+                        <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
+                            {shelfordInCount} trusts
+                        </span>
+                    </label>
+                    <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 {shelfordFilter === 'not_in' ? 'text-oxford-700' : ''}">
+                        <input
+                            type="checkbox"
+                            checked={shelfordFilter === 'not_in'}
+                            on:change={() => toggleShelford('not_in')}
+                            class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
+                        />
+                        <span class="truncate flex-1 min-w-0" title="Trusts not in the Shelford Group">Not in Shelford Group</span>
+                        <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
+                            {shelfordNotCount} trusts
+                        </span>
+                    </label>
+                {/if}
+            </div>
+        {/if}
+    </div>
+</div>

--- a/src/components/measures/Measure.svelte
+++ b/src/components/measures/Measure.svelte
@@ -59,6 +59,9 @@
     export let annotations = '[]';
     export let defaultviewmode = 'trust';
 
+    modeSelectorStore.setSelectedMode(defaultviewmode);
+    selectedMode.set(defaultviewmode);
+
     let trusts = [];
     let icbs = [];
     let regions = [];
@@ -966,7 +969,6 @@
             <div class="w-full sm:w-fit sm:min-w-[130px]">
                 <ModeSelector 
                     options={modeOptions}
-                    initialMode={defaultviewmode}
                     label="View by"
                     onChange={handleModeChange}
                     variant="dropdown"

--- a/src/components/measures/MeasuresListControls.svelte
+++ b/src/components/measures/MeasuresListControls.svelte
@@ -60,6 +60,22 @@
         { value: 'name', label: 'Alphabetical' },
         { value: 'newest', label: 'Newest first' },
     ];
+
+    function resolveInitialMeasuresMode() {
+        if (typeof window !== 'undefined') {
+            const urlMode = new URLSearchParams(window.location.search).get('mode');
+            if (['national', 'region', 'trust'].includes(urlMode)) {
+                return urlMode;
+            }
+        }
+        const rawMode = selectedMode || 'trust';
+        return ['national', 'region', 'trust'].includes(rawMode) ? rawMode : 'trust';
+    }
+
+    const seededMeasuresMode = resolveInitialMeasuresMode();
+    mode.set(seededMeasuresMode);
+    modeSelectorStore.setSelectedMode(seededMeasuresMode);
+
     $: selectedItems = $organisationSearchStore?.selectedItems || [];
 
     $: listPageTitle = (() => {
@@ -374,7 +390,6 @@
             <div class="w-full lg:w-fit lg:min-w-[130px]">
                 <ModeSelector
                     options={modeOptions}
-                    initialMode={$mode}
                     label="View by"
                     onChange={handleModeChange}
                     variant="dropdown"

--- a/src/stores/analyseOptionsStore.js
+++ b/src/stores/analyseOptionsStore.js
@@ -1,5 +1,9 @@
 import { writable } from 'svelte/store';
-import { organisationSearchStore } from './organisationSearchStore';
+import {
+    allOverlaySelection,
+    normaliseOverlaySelection,
+    overlayTrustsForModeChange,
+} from '../components/analyse/lib/chartOverlay.js';
 
 const createAnalyseOptionsStore = () => {
     const { subscribe, set, update } = writable({
@@ -9,7 +13,10 @@ const createAnalyseOptionsStore = () => {
         vmpNames: [],
         vtmNames: [],
         ingredientNames: [],
-        selectedOrganisations: []
+        selectedOrganisations: [],
+        rememberedOverlayOrganisations: [],
+        selectedChartRegions: allOverlaySelection(),
+        selectedChartIcbs: allOverlaySelection(),
     });
 
     const runAnalysis = (options) => {
@@ -24,15 +31,37 @@ const createAnalyseOptionsStore = () => {
         set,
         update,
         runAnalysis,
-        updateOrganisations: (organisations) => {
-            organisationSearchStore.setItems(organisations);
-            organisationSearchStore.setAvailableItems(organisations);
-            organisationSearchStore.setFilterType('trust');
-        },
         setSelectedOrganisations: (organisations) => {
             update(store => ({
                 ...store,
-                selectedOrganisations: organisations
+                selectedOrganisations: Array.isArray(organisations) ? organisations : []
+            }));
+        },
+        setRememberedOverlayOrganisations: (organisations) => {
+            update(store => ({
+                ...store,
+                rememberedOverlayOrganisations: Array.isArray(organisations) ? organisations : []
+            }));
+        },
+        applyOverlayModeChange: (fromMode, toMode) => {
+            update(store => {
+                const { patch } = overlayTrustsForModeChange(fromMode, toMode, {
+                    selectedOrganisations: store.selectedOrganisations,
+                    rememberedOverlayOrganisations: store.rememberedOverlayOrganisations,
+                });
+                return patch ? { ...store, ...patch } : store;
+            });
+        },
+        setSelectedChartRegions: (regions) => {
+            update(store => ({
+                ...store,
+                selectedChartRegions: normaliseOverlaySelection(regions),
+            }));
+        },
+        setSelectedChartIcbs: (icbs) => {
+            update(store => ({
+                ...store,
+                selectedChartIcbs: normaliseOverlaySelection(icbs),
             }));
         },
         setQuantityType: (quantityType) => {
@@ -45,5 +74,3 @@ const createAnalyseOptionsStore = () => {
 };
 
 export const analyseOptions = createAnalyseOptionsStore();
-
-

--- a/src/stores/modeSelectorStore.js
+++ b/src/stores/modeSelectorStore.js
@@ -1,28 +1,46 @@
 import { writable } from 'svelte/store';
+import { ANALYSIS_SCOPE } from '../components/analyse/lib/analysisScope.js';
+
+export function reconcileSelectedMode(selectedMode, availableModes = []) {
+    if (selectedMode == null) {
+        return null;
+    }
+
+    const values = availableModes.map((mode) =>
+        typeof mode === 'string' ? mode : mode?.value
+    );
+
+    return values.includes(selectedMode) ? selectedMode : null;
+}
+
+export function selectDefaultMode(availableModes, scope = ANALYSIS_SCOPE.ALL) {
+    if (scope === ANALYSIS_SCOPE.NATIONAL) {
+        const nationalModeForScope = availableModes.find((m) => m.value === 'national');
+        if (nationalModeForScope) return nationalModeForScope.value;
+    }
+
+    const trustMode = availableModes.find((m) => m.value === 'trust');
+    if (trustMode) return trustMode.value;
+
+    const nationalMode = availableModes.find((m) => m.value === 'national');
+    if (nationalMode) return nationalMode.value;
+
+    return availableModes[0]?.value || 'trust';
+}
 
 function createModeSelectorStore() {
     const { subscribe, set, update } = writable({
         selectedMode: null,
-        options: []
     });
 
     return {
         subscribe,
-        setOptions: (options) => {
-            update(state => ({ 
-                ...state, 
-                options,
-                selectedMode: options.some(opt => opt.value === state.selectedMode) 
-                    ? state.selectedMode 
-                    : (options.length > 0 ? options[0].value : null)
-            }));
-        },
         setSelectedMode: (mode) => {
-            update(state => ({ ...state, selectedMode: mode }));
+            update((state) => ({ ...state, selectedMode: mode }));
         },
         reset: () => {
-            set({ selectedMode: null, options: [] });
-        }
+            set({ selectedMode: null });
+        },
     };
 }
 

--- a/src/stores/organisationSearchStore.js
+++ b/src/stores/organisationSearchStore.js
@@ -1,4 +1,5 @@
 import { writable, get } from 'svelte/store';
+import { applyScopeFiltersToSource, CANCER_ALLIANCE_NA } from '../utils/scopeFilters.js';
 
 function createOrganisationSearchStore() {
     const { subscribe, set, update } = writable({
@@ -109,6 +110,21 @@ function createOrganisationSearchStore() {
                 };
             });
         },
+
+        applyScopeFilters(filters) {
+            const store = get(this);
+            const { orgList, hasFilters } = applyScopeFiltersToSource({
+                allItems: store.items || [],
+                filters,
+                getTrustType: (name) => this.getTrustType(name),
+                getOrgsByRegionsOrICBs: (regions, icbs) => this.getOrgsByRegionsOrICBs(regions, icbs),
+                getOrgsByCancerAlliances: (alliances) => this.getOrgsByCancerAlliances(alliances),
+                orgShelfordGroup: store.orgShelfordGroup,
+            });
+            this.setFiltersApplied(hasFilters);
+            this.setAvailableItems(orgList);
+            return { orgList, hasFilters };
+        },
         
         isAvailable(item) {
             const currentStore = get(this);
@@ -139,7 +155,6 @@ function createOrganisationSearchStore() {
             return types.sort((a, b) => a.localeCompare(b));
         },
 
-        /** Returns orgs by trust type from the full items set */
         getOrgsByTrustTypeGlobal(trustType) {
             const currentStore = get(this);
             if (!currentStore.trustTypes || !trustType) return [];
@@ -201,7 +216,7 @@ function createOrganisationSearchStore() {
             const result = new Set();
             if (selectedCancerAlliances && selectedCancerAlliances.size > 0) {
                 selectedCancerAlliances.forEach((caName) => {
-                    if (caName === 'Not applicable') {
+                    if (caName === CANCER_ALLIANCE_NA) {
                         this.getOrgsWithNoCancerAlliance().forEach((name) => result.add(name));
                     } else {
                         this.getOrgsByCancerAlliance(caName).forEach((name) => result.add(name));

--- a/src/stores/resultsModeSearchStore.js
+++ b/src/stores/resultsModeSearchStore.js
@@ -1,0 +1,38 @@
+import { get, writable } from 'svelte/store';
+
+export function createResultsModeSearchStore() {
+    const { subscribe, update } = writable({
+        filterType: 'trust',
+        items: [],
+        selectedItems: [],
+        availableItems: new Set()
+    });
+
+    function setItems(items = [], filterType = 'trust') {
+        const uniqueItems = Array.from(new Set((items || []).filter(Boolean)));
+        const availableItems = new Set(uniqueItems);
+        update(store => ({
+            ...store,
+            filterType,
+            items: uniqueItems,
+            selectedItems: (store.selectedItems || []).filter(item => availableItems.has(item)),
+            availableItems
+        }));
+    }
+
+    function updateSelection(selectedItems = []) {
+        const nextSelected = Array.isArray(selectedItems) ? selectedItems : [];
+        update(store => ({
+            ...store,
+            selectedItems: nextSelected.filter(item => store.availableItems.has(item))
+        }));
+    }
+
+    return {
+        subscribe,
+        setItems,
+        updateSelection,
+        isAvailable: (item) => get({ subscribe }).availableItems.has(item),
+        getDisplayName: (item) => item || ''
+    };
+}

--- a/src/stores/resultsStore.js
+++ b/src/stores/resultsStore.js
@@ -1,5 +1,6 @@
 import { writable } from 'svelte/store';
-import { processAnalysisData } from '../utils/analyseUtils.js';
+import { processAnalysisData } from '../components/analyse/lib/analyseData.js';
+import { createEmptyScopeFilters, normaliseScopeFilters } from '../utils/scopeFilters.js';
 
 export const resultsStore = writable({
     isAnalysisRunning: false,
@@ -22,8 +23,40 @@ export const resultsStore = writable({
     percentiles: [],
     trustCount: 0,
     excludedTrusts: [],
-    excludedVmps: []
+    excludedVmps: [],
+    scope: 'all',
+    scopeFilters: createEmptyScopeFilters(),
+    inScopeTrusts: []
 });
+
+export function setAnalysisRunning(isRunning) {
+    resultsStore.update(store => ({
+        ...store,
+        isAnalysisRunning: !!isRunning,
+        ...(isRunning ? { showResults: true } : {}),
+    }));
+}
+
+export function clearAnalysisResults() {
+    resultsStore.update(store => ({
+        ...store,
+        isAnalysisRunning: false,
+        showResults: false,
+        analysisData: null,
+        analysisMonths: null,
+        filteredData: null,
+        productData: {},
+        organisationData: {},
+        aggregatedData: { regions: {}, icbs: {}, national: {} },
+        percentiles: [],
+        trustCount: 0,
+        excludedTrusts: [],
+        excludedVmps: [],
+        inScopeTrusts: [],
+        scope: 'all',
+        scopeFilters: createEmptyScopeFilters(),
+    }));
+}
 
 export function updateResults(data, options = {}) {
     const months = data?.months ?? [];
@@ -75,6 +108,9 @@ export function updateResults(data, options = {}) {
         aggregatedData,
         quantityType: options.quantityType || store.quantityType,
         searchType: options.searchType || store.searchType,
+        scope: options.scope || 'all',
+        scopeFilters: normaliseScopeFilters(options.scopeFilters),
+        inScopeTrusts: Array.isArray(options.inScopeTrusts) ? options.inScopeTrusts : [],
         dateRange: calculateDateRange(months),
         selectedOrganisations: options.selectedOrganisations || [],
         showPercentiles: showPercentilesValue,

--- a/src/utils/scopeFilters.js
+++ b/src/utils/scopeFilters.js
@@ -1,0 +1,207 @@
+export const ACUTE_PREFIX = 'Acute - ';
+export const ACUTE_PARENT = 'Acute';
+
+/** Display name → short URL slug. */
+export const TRUST_TYPE_URL_SLUGS = {
+    [ACUTE_PARENT]: 'acute',
+    'Acute - Large': 'acute-large',
+    'Acute - Medium': 'acute-medium',
+    'Acute - Multi-Service': 'acute-multi-service',
+    'Acute - Small': 'acute-small',
+    'Acute - Specialist': 'acute-specialist',
+    'Acute - Teaching': 'acute-teaching',
+    Ambulance: 'ambulance',
+    'Care Trust': 'care',
+    Community: 'community',
+    'Mental Health And Learning Disability': 'mhld',
+};
+
+const TRUST_TYPE_FROM_URL_SLUG = new Map(
+    Object.entries(TRUST_TYPE_URL_SLUGS).map(([name, slug]) => [slug, name])
+);
+
+export function isAcuteType(type) {
+    return typeof type === 'string' && type.startsWith(ACUTE_PREFIX);
+}
+
+export function acuteSubtypeLabel(type) {
+    return type.slice(ACUTE_PREFIX.length).trim();
+}
+
+function selectionHas(selected, value) {
+    return selected instanceof Set ? selected.has(value) : selected.includes(value);
+}
+
+/** Parent `Acute` matches every `Acute - …` subtype. */
+export function trustTypeMatchesSelection(trustType, selectedTrustTypes) {
+    if (!trustType) return false;
+    if (selectionHas(selectedTrustTypes, trustType)) return true;
+    return selectionHas(selectedTrustTypes, ACUTE_PARENT) && isAcuteType(trustType);
+}
+
+export function normaliseAcuteSelection(types, acuteTypes, { asArray = false } = {}) {
+    const next = new Set(Array.isArray(types) ? types : [...types]);
+    if (
+        next.has(ACUTE_PARENT) ||
+        (acuteTypes.length > 0 && acuteTypes.every((type) => next.has(type)))
+    ) {
+        acuteTypes.forEach((type) => next.delete(type));
+        next.add(ACUTE_PARENT);
+    }
+    return asArray ? Array.from(next).sort() : next;
+}
+
+/** `Care Trust` → `care`, `Acute - Teaching` → `acute-teaching`. */
+export function encodeTrustTypeForUrl(type) {
+    if (!type || typeof type !== 'string') return type;
+    return TRUST_TYPE_URL_SLUGS[type] || type;
+}
+
+export function decodeTrustTypeFromUrl(value) {
+    if (!value) return value;
+
+    const trimmed = value.trim();
+    const normalised = trimmed.toLowerCase();
+
+    if (TRUST_TYPE_FROM_URL_SLUG.has(normalised)) {
+        return TRUST_TYPE_FROM_URL_SLUG.get(normalised);
+    }
+
+    const knownName = Object.keys(TRUST_TYPE_URL_SLUGS).find(
+        (name) => name.toLowerCase() === normalised
+    );
+    if (knownName) return knownName;
+
+    return trimmed;
+}
+
+export const CANCER_ALLIANCE_NA = 'na';
+
+/** Strip trailing "Cancer Alliance" for UI labels. */
+export function cancerAllianceDisplayName(name) {
+    if (typeof name !== 'string') return name;
+    if (name === CANCER_ALLIANCE_NA) {
+        return 'Not applicable';
+    }
+    const trimmed = name.replace(/\s+Cancer Alliance$/i, '').trim();
+    return trimmed || name;
+}
+
+export function createEmptyScopeFilters() {
+    return {
+        trustTypes: [],
+        regions: [],
+        icbs: [],
+        cancerAlliances: [],
+        shelford: null
+    };
+}
+
+function collectionSize(value) {
+    if (!value) return 0;
+    if (value instanceof Set) return value.size;
+    return Array.isArray(value) ? value.length : 0;
+}
+
+export function normaliseScopeFilters(filters = {}) {
+    const shelford =
+        filters?.shelford === 'in' || filters?.shelford === 'not_in' ? filters.shelford : null;
+    const cancerAlliances = Array.isArray(filters?.cancerAlliances)
+        ? filters.cancerAlliances.map(String).filter(Boolean)
+        : [];
+    return {
+        trustTypes: Array.isArray(filters?.trustTypes) ? filters.trustTypes.map(String).filter(Boolean) : [],
+        regions: Array.isArray(filters?.regions) ? filters.regions.map(String).filter(Boolean) : [],
+        icbs: Array.isArray(filters?.icbs) ? filters.icbs.map(String).filter(Boolean) : [],
+        cancerAlliances,
+        shelford
+    };
+}
+
+export function hasAnyScopeFilters(filters) {
+    if (!filters) return false;
+    return (
+        collectionSize(filters.trustTypes) > 0 ||
+        collectionSize(filters.regions) > 0 ||
+        collectionSize(filters.icbs) > 0 ||
+        collectionSize(filters.cancerAlliances) > 0 ||
+        filters.shelford === 'in' ||
+        filters.shelford === 'not_in'
+    );
+}
+
+export function applyScopeFiltersToSource({
+    allItems,
+    filters,
+    getTrustType,
+    getOrgsByRegionsOrICBs,
+    getOrgsByCancerAlliances,
+    orgShelfordGroup,
+}) {
+    const normalised = normaliseScopeFilters(filters);
+    const orgList = filterTrustNamesByScope({
+        allItems,
+        getTrustType,
+        getOrgsByRegionsOrICBs,
+        getOrgsByCancerAlliances,
+        orgShelfordGroup,
+        selectedTrustTypes: normalised.trustTypes,
+        selectedRegions: new Set(normalised.regions),
+        selectedICBs: new Set(normalised.icbs),
+        selectedCancerAlliances: new Set(normalised.cancerAlliances),
+        shelfordFilter: normalised.shelford,
+    });
+    return {
+        normalised,
+        orgList,
+        hasFilters: hasAnyScopeFilters(normalised),
+    };
+}
+
+export function filterTrustNamesByScope({
+    allItems,
+    getTrustType,
+    getOrgsByRegionsOrICBs,
+    getOrgsByCancerAlliances,
+    orgShelfordGroup,
+    selectedTrustTypes,
+    selectedRegions,
+    selectedICBs,
+    selectedCancerAlliances,
+    shelfordFilter
+}) {
+    const trustTypeCount = collectionSize(selectedTrustTypes);
+    let orgList = Array.from(allItems || []);
+
+    if (trustTypeCount > 0 && getTrustType) {
+        orgList = orgList.filter((name) =>
+            trustTypeMatchesSelection(getTrustType(name), selectedTrustTypes)
+        );
+    }
+
+    // AND across filter categories so each selected dimension narrows the cohort.
+    if (collectionSize(selectedRegions) > 0 || collectionSize(selectedICBs) > 0) {
+        const byRegionIcb = getOrgsByRegionsOrICBs
+            ? getOrgsByRegionsOrICBs(selectedRegions, selectedICBs)
+            : [];
+        const regionSet = new Set(byRegionIcb);
+        orgList = orgList.filter((name) => regionSet.has(name));
+    }
+
+    if (collectionSize(selectedCancerAlliances) > 0) {
+        const byCancerAlliance = getOrgsByCancerAlliances
+            ? getOrgsByCancerAlliances(selectedCancerAlliances)
+            : [];
+        const cancerSet = new Set(byCancerAlliance);
+        orgList = orgList.filter((name) => cancerSet.has(name));
+    }
+
+    if (shelfordFilter !== null) {
+        const map = orgShelfordGroup || new Map();
+        orgList = orgList.filter((name) =>
+            shelfordFilter === 'in' ? map.get(name) === true : !map.get(name)
+        );
+    }
+
+    return orgList;
+}

--- a/templates/analyse.html
+++ b/templates/analyse.html
@@ -15,7 +15,6 @@
         maxDate="{{ date_range.max_date }}"
         orgData="{{ org_data }}"
         maxVmpCount="{{ max_vmp_count }}"
-        {% if user.is_authenticated %}isAuthenticated="true"{% endif %}
     ></layout-component>
 </div>
 {% endblock %}

--- a/templates/analyse.html
+++ b/templates/analyse.html
@@ -15,6 +15,7 @@
         maxDate="{{ date_range.max_date }}"
         orgData="{{ org_data }}"
         maxVmpCount="{{ max_vmp_count }}"
+        {% if user.is_authenticated %}isAuthenticated="true"{% endif %}
     ></layout-component>
 </div>
 {% endblock %}

--- a/viewer/content/faq/05_analyse.md
+++ b/viewer/content/faq/05_analyse.md
@@ -10,13 +10,24 @@ Quantity is the total amount of a medicine that has been issued as reported in t
 
 There is no quantity reported when a trust has not issued a product or the selected [quantity type](/faq/#what-does-quantity-mean) is not available for the product. See [How is the quantity type used for an analysis chosen?](faq/#how-is-the-quantity-type-used-for-an-analysis-chosen).
 
+### What is analysis scope?
+
+The scope of an analysis specifies which NHS trusts are included and the level of reporting available in the results. You choose a scope in the analysis builder. The options are:
+
+- **All trusts**: Includes all NHS trusts in the analysis. This gives access to trust-level charts and tables, as well as ICB, regional, and national breakdowns, and trust-level percentile charts.
+- **National**: Shows nationally aggregated totals only. Trust-level, ICB, and regional breakdowns are not available. Use this when you only need a national total for the selected products.
+- **Single trust**: Restricts the analysis to one NHS trust that you select. Results show data for that trust only.
+- **Trust group**: Restricts the analysis to a group of NHS trusts defined by filters such as [trust type](/faq/#how-are-trust-types-determined), region, ICB, [Cancer Alliance](/faq/#where-do-cancer-alliance-boundaries-come-from), or [Shelford Group](https://shelfordgroup.org/) membership. Results and comparisons (including percentiles, where available) are based on the trusts in that group.
+
+See also [which NHS trusts are included](/faq/#which-nhs-trusts-are-included).
+
 ### How do I see ICB, regional, and national breakdowns?
 
-To view ICB, regional, and national analysis breakdowns, as well as national trust-level variation as a percentiles chart, run an analysis **without selecting any NHS Trusts** in the analysis builder. These geographic breakdown modes are only available when analysing data across all trusts.
+To view ICB, regional, and national analysis breakdowns, as well as trust-level variation as a percentiles chart, choose the **All trusts** or **Trust group** scope in the analysis builder. With **Trust group**, these breakdowns only include the trusts in the scope for this analysis (for example, regional totals across acute trusts only), not all trusts in England. Percentile charts are available when the filtered group is large enough. See [What is analysis scope?](/faq/#what-is-analysis-scope).
 
 ### How do I restrict an analysis to a specific set of NHS Trusts?
 
-To restrict an analysis to a specific set of NHS Trusts, select the NHS Trusts you want to include in the analysis builder. This will filter the analysis to show only data from your selected trusts.
+To restrict an analysis to a specific set of NHS Trusts, use **Single trust** to select one trust, or **Trust group** to filter trusts by attributes such as [trust type](/faq/#how-are-trust-types-determined), region, or ICB. See [What is analysis scope?](/faq/#what-is-analysis-scope).
 
 ### What is SCMD quantity?
 

--- a/viewer/tests/test_api.py
+++ b/viewer/tests/test_api.py
@@ -19,7 +19,7 @@ from viewer.models import (
     PrecomputedMeasure,
     PrecomputedPercentile,
 )
-from viewer.views.api import MAX_ANALYSIS_VMP_COUNT
+from viewer.search import MAX_ANALYSIS_VMP_COUNT
 
 
 @pytest.fixture
@@ -82,6 +82,33 @@ def measure(vmp):
     return measure
 
 
+def _quantity_payload(vmp, *, ods_codes=None, scope="all"):
+    payload = {
+        "names": [{"code": vmp.code, "type": "vmp"}],
+        "quantity_type": "Defined Daily Dose Quantity",
+        "scope": scope,
+    }
+    if ods_codes is not None:
+        payload["ods_codes"] = ods_codes
+    return payload
+
+
+def _post_quantity_data(client, payload):
+    return client.post(
+        reverse("viewer:get_quantity_data"),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+def _org_items(items, ods_name):
+    return [
+        item
+        for item in items
+        if item.get("organisation__ods_name") == ods_name
+    ]
+
+
 @pytest.mark.django_db
 class TestGetQuantityData:
     def test_predecessor_data_aggregated_into_successor(
@@ -106,41 +133,32 @@ class TestGetQuantityData:
             data=[5.0, 15.0, 25.0],
         )
 
-        client = Client()
-        payload = {
-            "names": [{"code": vmp.code, "type": "vmp"}],
-            "quantity_type": "Defined Daily Dose Quantity",
-            "ods_names": [successor.ods_name],
-        }
-        response = client.post(
-            reverse("viewer:get_quantity_data"),
-            data=json.dumps(payload),
-            content_type="application/json",
+        response = _post_quantity_data(
+            Client(),
+            _quantity_payload(vmp, ods_codes=[successor.ods_code]),
         )
 
         assert response.status_code == 200
-        data = response.json()
-        items = data["items"]
-
-        org_items = [
-            i
-            for i in items
-            if i.get("organisation__ods_name") == successor.ods_name
-        ]
+        org_items = _org_items(response.json()["items"], successor.ods_name)
         assert len(org_items) == 1, "Should have exactly one item for successor"
-        org_item = org_items[0]
+        assert org_items[0]["data"] == [15.0, 35.0, 55.0]
+        assert org_items[0]["organisation__ods_code"] == successor.ods_code
 
-        expected_data = [15.0, 35.0, 55.0]
-        assert org_item["data"] == expected_data
-
-    def test_filter_by_successor_includes_predecessor_rows(
-        self, predecessor_successor_orgs, vmp, data_status_months
+    def test_filter_by_successor_ods_code_includes_predecessor_rows(
+        self, predecessor_successor_orgs, region, icb, vmp, data_status_months
     ):
         """
-        Filtering by successor ods_name should include both successor and
-        predecessor DDDQuantity rows.
+        Filtering by successor ods_code should include both successor and
+        predecessor DDDQuantity rows, and exclude unrelated trusts.
         """
         predecessor, successor = predecessor_successor_orgs
+        other = Organisation.objects.create(
+            ods_code="OTH",
+            ods_name="Other Trust",
+            region=region,
+            icb=icb,
+            successor=None,
+        )
 
         DDDQuantity.objects.create(
             vmp=vmp,
@@ -152,28 +170,23 @@ class TestGetQuantityData:
             organisation=successor,
             data=[0, 50.0, 0],
         )
+        DDDQuantity.objects.create(
+            vmp=vmp,
+            organisation=other,
+            data=[999.0, 999.0, 999.0],
+        )
 
-        client = Client()
-        payload = {
-            "names": [{"code": vmp.code, "type": "vmp"}],
-            "quantity_type": "Defined Daily Dose Quantity",
-            "ods_names": [successor.ods_name],
-        }
-        response = client.post(
-            reverse("viewer:get_quantity_data"),
-            data=json.dumps(payload),
-            content_type="application/json",
+        response = _post_quantity_data(
+            Client(),
+            _quantity_payload(vmp, ods_codes=[successor.ods_code]),
         )
 
         assert response.status_code == 200
-        data = response.json()
-        org_items = [
-            i
-            for i in data["items"]
-            if i.get("organisation__ods_name") == successor.ods_name
-        ]
+        items = response.json()["items"]
+        org_items = _org_items(items, successor.ods_name)
         assert len(org_items) == 1
         assert org_items[0]["data"] == [100.0, 50.0, 0.0]
+        assert _org_items(items, other.ods_name) == []
 
     def test_org_without_successor_returns_own_data(
         self, region, icb, vmp, data_status_months
@@ -192,27 +205,62 @@ class TestGetQuantityData:
             data=[1.0, 2.0, 3.0],
         )
 
-        client = Client()
-        payload = {
-            "names": [{"code": vmp.code, "type": "vmp"}],
-            "quantity_type": "Defined Daily Dose Quantity",
-            "ods_names": [org.ods_name],
-        }
-        response = client.post(
-            reverse("viewer:get_quantity_data"),
-            data=json.dumps(payload),
-            content_type="application/json",
+        response = _post_quantity_data(
+            Client(),
+            _quantity_payload(vmp, ods_codes=[org.ods_code]),
         )
 
         assert response.status_code == 200
-        data = response.json()
-        org_items = [
-            i
-            for i in data["items"]
-            if i.get("organisation__ods_name") == org.ods_name
-        ]
+        org_items = _org_items(response.json()["items"], org.ods_name)
         assert len(org_items) == 1
         assert org_items[0]["data"] == [1.0, 2.0, 3.0]
+
+    def test_national_scope_returns_aggregated_totals(
+        self, predecessor_successor_orgs, region, icb, vmp, data_status_months
+    ):
+        predecessor, successor = predecessor_successor_orgs
+        other = Organisation.objects.create(
+            ods_code="OTH",
+            ods_name="Other Trust",
+            region=region,
+            icb=icb,
+            successor=None,
+        )
+        DDDQuantity.objects.create(
+            vmp=vmp,
+            organisation=predecessor,
+            data=[10.0, 0, 0],
+        )
+        DDDQuantity.objects.create(
+            vmp=vmp,
+            organisation=successor,
+            data=[5.0, 20.0, 0],
+        )
+        DDDQuantity.objects.create(
+            vmp=vmp,
+            organisation=other,
+            data=[1.0, 2.0, 3.0],
+        )
+
+        user = User.objects.create_user(username="analyst", password="pass")
+        client = Client()
+        client.force_login(user)
+
+        response = _post_quantity_data(
+            client,
+            _quantity_payload(vmp, scope="national"),
+        )
+
+        assert response.status_code == 200
+        items = [
+            item
+            for item in response.json()["items"]
+            if item.get("vmp__code") == vmp.code
+        ]
+        assert len(items) == 1
+        assert items[0]["organisation__ods_code"] is None
+        assert items[0]["organisation__ods_name"] is None
+        assert items[0]["data"] == [16.0, 22.0, 3.0]
 
 
 @pytest.mark.django_db

--- a/viewer/views/api.py
+++ b/viewer/views/api.py
@@ -39,6 +39,64 @@ from .measures import (
     series_dict_to_chart_points,
 )
 
+
+def add_quantity_data(existing, new_data):
+    """Element-wise sum of new_data into existing, padding with zeros."""
+    new_data = new_data or []
+    for i in range(max(len(existing), len(new_data))):
+        while len(existing) <= i:
+            existing.append(0)
+        add_val = float(new_data[i] or 0) if i < len(new_data) else 0
+        existing[i] = existing[i] + add_val
+
+
+def group_quantity_rows(quantity_data, *, national):
+    """Group quantity rows by VMP (national) or (VMP, effective org)."""
+    grouped = {}
+    for item in quantity_data:
+        if national:
+            key = item.vmp_id
+            effective_org = None
+        else:
+            org = item.organisation
+            effective_org = org.successor if org.successor_id else org
+            key = (item.vmp_id, effective_org.id)
+
+        if key not in grouped:
+            grouped[key] = {
+                'item': item,
+                'effective_org': effective_org,
+                'data': list(item.data or []),
+            }
+        else:
+            add_quantity_data(grouped[key]['data'], item.data)
+    return grouped
+
+
+def build_quantity_response_row(
+    base_metadata, vmp_id, group, quantity_type, ddd_unit_map
+):
+    source_item = group['item'] if group else None
+    effective_org = group['effective_org'] if group else None
+    return {
+        **base_metadata,
+        'organisation__ods_code': effective_org.ods_code if effective_org else None,
+        'organisation__ods_name': effective_org.ods_name if effective_org else None,
+        'organisation__region': (
+            effective_org.region.name if effective_org and effective_org.region else None
+        ),
+        'organisation__icb': (
+            effective_org.icb.name if effective_org and effective_org.icb else None
+        ),
+        'data': group['data'] if group else [],
+        'unit': (
+            ddd_unit_map.get(vmp_id, "DDD")
+            if quantity_type == "Defined Daily Dose Quantity"
+            else (source_item.unit if source_item else None)
+        ),
+    }
+
+
 @api_view(["GET"])
 def search_products(request):
     search_type = request.GET.get("type", "product")
@@ -331,7 +389,8 @@ def _populate_ddd_quantity_info(vmp_ids, vmp_info):
 @api_view(["POST"])
 def get_quantity_data(request):
     search_items = request.data.get("names", None)
-    ods_names = request.data.get("ods_names", None)
+    ods_codes = request.data.get("ods_codes", None)
+    scope = request.data.get("scope", "all")
     quantity_type = request.data.get("quantity_type", None)
     
     if not all([search_items, quantity_type]):
@@ -359,6 +418,9 @@ def get_quantity_data(request):
         return Response({"error": "No valid VMPs found"}, status=400)
 
     try:
+        scope_value = scope.strip().lower() if isinstance(scope, str) else "all"
+        is_national_scope = scope_value == "national"
+
         base_vmps = list(VMP.objects.filter(
             id__in=vmp_ids
         ).select_related('vtm').annotate(
@@ -383,15 +445,15 @@ def get_quantity_data(request):
                 'ingredient_codes': ingredient_codes
             }
             base_vmp_metadata[vmp['id']] = base_metadata
-            response_item = {
-                **base_metadata,
-                'organisation__ods_code': None,
-                'organisation__ods_name': None,
-                'organisation__region': None,
-                'organisation__icb': None,
-                'data': []
-            }
-            response_data.append(response_item)
+            if not is_national_scope:
+                response_data.append({
+                    **base_metadata,
+                    'organisation__ods_code': None,
+                    'organisation__ods_name': None,
+                    'organisation__region': None,
+                    'organisation__icb': None,
+                    'data': []
+                })
 
         quantity_model = {
             "SCMD Quantity": SCMDQuantity,
@@ -405,65 +467,44 @@ def get_quantity_data(request):
             quantity_queryset = quantity_model.objects.filter(
                 vmp_id__in=vmp_ids
             )
-            if ods_names:
+            if not is_national_scope and isinstance(ods_codes, list) and len(ods_codes) > 0:
                 quantity_queryset = quantity_queryset.filter(
-                    Q(organisation__ods_name__in=ods_names)
-                    | Q(organisation__successor__ods_name__in=ods_names)
+                    Q(organisation__ods_code__in=ods_codes)
+                    | Q(organisation__successor__ods_code__in=ods_codes)
                 )
             select_related_fields = [
                 'vmp',
                 'vmp__vtm',
-                'organisation',
-                'organisation__region',
-                'organisation__icb',
-                'organisation__successor',
             ]
+            if not is_national_scope:
+                select_related_fields.extend([
+                    'organisation',
+                    'organisation__region',
+                    'organisation__icb',
+                    'organisation__successor',
+                ])
             if quantity_model is not DDDQuantity:
                 select_related_fields.append('quantity_unit')
             quantity_queryset = quantity_queryset.select_related(*select_related_fields)
             quantity_data = list(quantity_queryset)
 
-            grouped = {}
-            for item in quantity_data:
-                org = item.organisation
-                effective_org = org.successor if org.successor_id else org
-                key = (item.vmp_id, effective_org.id)
-                if key not in grouped:
-                    grouped[key] = {
-                        'item': item,
-                        'effective_org': effective_org,
-                        'data': list(item.data or []),
-                    }
-                else:
-                    existing = grouped[key]['data']
-                    new_data = item.data or []
-                    for i in range(max(len(existing), len(new_data))):
-                        while len(existing) <= i:
-                            existing.append(0)
-                        add_val = float(new_data[i] or 0) if i < len(new_data) else 0
-                        existing[i] = existing[i] + add_val
-
-            for (vmp_id, _), group in grouped.items():
-                item = group['item']
-                effective_org = group['effective_org']
-                base_metadata = base_vmp_metadata.get(vmp_id)
-                ingredient_names = base_metadata['ingredient_names'] if base_metadata else [ing.name for ing in item.vmp.ingredients.all()]
-                ingredient_codes = base_metadata['ingredient_codes'] if base_metadata else [ing.code for ing in item.vmp.ingredients.all()]
-                response_item = {
-                    'vmp__code': base_metadata['vmp__code'] if base_metadata else item.vmp.code,
-                    'vmp__name': base_metadata['vmp__name'] if base_metadata else item.vmp.name,
-                    'vmp__vtm__vtm': base_metadata['vmp__vtm__vtm'] if base_metadata else (item.vmp.vtm.vtm if item.vmp.vtm else None),
-                    'vmp__vtm__name': base_metadata['vmp__vtm__name'] if base_metadata else (item.vmp.vtm.name if item.vmp.vtm else None),
-                    'ingredient_names': ingredient_names,
-                    'ingredient_codes': ingredient_codes,
-                    'organisation__ods_code': effective_org.ods_code,
-                    'organisation__ods_name': effective_org.ods_name,
-                    'organisation__region': effective_org.region.name if effective_org.region else None,
-                    'organisation__icb': effective_org.icb.name if effective_org.icb else None,
-                    'data': group['data'],
-                    'unit': ddd_unit_map.get(vmp_id, "DDD") if quantity_type == "Defined Daily Dose Quantity" else item.unit,
-                }
-                response_data.append(response_item)
+            grouped = group_quantity_rows(quantity_data, national=is_national_scope)
+            if is_national_scope:
+                emit_items = (
+                    (vmp_id, base_vmp_metadata[vmp_id], grouped.get(vmp_id))
+                    for vmp_id in base_vmp_metadata
+                )
+            else:
+                emit_items = (
+                    (vmp_id, base_vmp_metadata[vmp_id], group)
+                    for (vmp_id, _), group in grouped.items()
+                )
+            for vmp_id, base_metadata, group in emit_items:
+                response_data.append(
+                    build_quantity_response_row(
+                        base_metadata, vmp_id, group, quantity_type, ddd_unit_map
+                    )
+                )
 
         months = get_quantity_months()
         return Response({"months": months, "items": response_data})
@@ -731,7 +772,6 @@ def build_single_product_data(vmp, quantity_data):
         'ddd_logic': ddd_logic,
         'ingredient_logic': ingredient_logic
     }
-
 
 
 def validate_and_sanitize_codes(codes_list, max_length, code_type, regex_pattern=None, numeric_only=False, errors=None, allowed_lengths=None):

--- a/viewer/views/api.py
+++ b/viewer/views/api.py
@@ -419,6 +419,9 @@ def get_quantity_data(request):
 
     try:
         scope_value = scope.strip().lower() if isinstance(scope, str) else "all"
+        if not request.user.is_authenticated and scope_value != "all":
+            scope_value = "all"
+            ods_codes = []
         is_national_scope = scope_value == "national"
 
         base_vmps = list(VMP.objects.filter(


### PR DESCRIPTION
Add analysis scope to the Analyse builder so users can choose **All trusts**, **National**, **Single trust**, or **Trust group** (filtered by trust type, region, ICB, Cancer Alliance, Shelford Group).

This is currently limited to authenticated users.