### PR TITLE
Fix bnf code padding in dmd supplementary data

### DIFF
--- a/pipeline/dmd/import_dmd_supp.py
+++ b/pipeline/dmd/import_dmd_supp.py
@@ -26,6 +26,21 @@ from pipeline.atc_ddd.import_atc_ddd.import_atc import create_atc_code_mapping
 TEMP_DIR = Path("temp")
 
 
+def normalise_bnf_code(bnf_code: Optional[str]) -> Optional[str]:
+    """Drop the spurious leading zero on an 8-char dm+d BNF subparagraph.
+
+    NHS BNF hierarchy is chapter(2)+section(2)+paragraph(2)+subparagraph(1).
+    dm+d BNF truncs are often stored as 8 chars with a zero-padded subparagraph
+    in the dm+d supplementary data (e.g. 05010103 instead of 0501013). 
+    Longer chemical/presentation codes are left unchanged.
+    """
+    if bnf_code is None:
+        return None
+    if len(bnf_code) == 8 and bnf_code[6] == "0":
+        return bnf_code[:6] + bnf_code[7]
+    return bnf_code
+
+
 @dataclass
 class TRUDRelease:
     release_date: str
@@ -183,7 +198,7 @@ def parse_xml_data(xml_path: Path) -> List[Dict[str, Optional[str]]]:
         data.append(
             {
                 "vmp_code": str(vmp_code) if vmp_code is not None else None,
-                "bnf_code": str(bnf_code.text)
+                "bnf_code": normalise_bnf_code(str(bnf_code.text))
                 if bnf_code is not None and bnf_code.text is not None
                 else None,
                 "atc_code": str(atc_code.text)

--- a/pipeline/tests/dmd/test_import_dmd_supp.py
+++ b/pipeline/tests/dmd/test_import_dmd_supp.py
@@ -1,11 +1,28 @@
 import pytest
 
 from pipeline.dmd.import_dmd_supp import (
+    normalise_bnf_code,
     parse_xml_data,
     parse_vtm_ingredients_xml,
     parse_dmd_history_xml,
     update_atc_codes
 )
+
+
+class TestNormaliseBnfCode:
+    def test_de_pads_eight_char_subparagraph(self):
+        assert normalise_bnf_code("05010103") == "0501013"
+        assert normalise_bnf_code("01010100") == "0101010"
+        assert normalise_bnf_code("10030200") == "1003020"
+
+    def test_leaves_seven_char_and_longer_codes_unchanged(self):
+        assert normalise_bnf_code("0501013") == "0501013"
+        assert normalise_bnf_code("0403030E0") == "0403030E0"
+        assert normalise_bnf_code("0501013B0AAABAB") == "0501013B0AAABAB"
+
+    def test_leaves_none_and_non_padded_eight_char_unchanged(self):
+        assert normalise_bnf_code(None) is None
+        assert normalise_bnf_code("05010113") == "05010113"
 
 @pytest.fixture
 def sample_xml_content():
@@ -30,6 +47,11 @@ def sample_xml_content():
                 <ATC>N02BE01</ATC>
                 <DDD>invalid</DDD>
                 <DDD_UOMCD>mg</DDD_UOMCD>
+            </VMP>
+            <VMP>
+                <VPID>39732411000001106</VPID>
+                <BNF>05010103</BNF>
+                <ATC>J01CA04</ATC>
             </VMP>
         </VMPS>
     </DMDXML>'''
@@ -107,7 +129,7 @@ class TestXMLParsing:
         
         result = parse_xml_data(xml_file)
         
-        assert len(result) == 3
+        assert len(result) == 4
         assert result[0] == {
             'vmp_code': '12345',
             'bnf_code': '0403030E0',
@@ -116,6 +138,13 @@ class TestXMLParsing:
             'ddd_uom': 'mg'
         }
         assert result[2]['ddd'] is None
+        assert result[3] == {
+            'vmp_code': '39732411000001106',
+            'bnf_code': '0501013',
+            'atc_code': 'J01CA04',
+            'ddd': None,
+            'ddd_uom': None
+        }
         
     def test_parse_vtm_ingredients_xml(self, sample_vtm_ingredients_xml_content, tmp_path):
         xml_file = tmp_path / "test_vtm_ing.xml"

--- a/src/components/dq/ProductDetails.svelte
+++ b/src/components/dq/ProductDetails.svelte
@@ -352,6 +352,17 @@
                             <span class="text-sm font-medium whitespace-nowrap">VMP code:</span>
                             <span class="text-sm break-words hyphens-auto min-w-0">{product.vmp_code}</span>
                           </div>
+
+                          <div class="grid grid-cols-[auto_1fr] gap-3 items-baseline">
+                            <span class="text-sm font-medium whitespace-nowrap">BNF code:</span>
+                            <span class="text-sm break-words hyphens-auto min-w-0">
+                              {#if product.bnf_code}
+                                {product.bnf_code}
+                              {:else}
+                                <span class="text-gray-400">-</span>
+                              {/if}
+                            </span>
+                          </div>
                           
                           <div class="grid grid-cols-[auto_1fr] gap-3 items-start">
                             <span class="text-sm font-medium whitespace-nowrap">Ingredients:</span>

--- a/viewer/measures/lvp_rubefacients/vmps.sql
+++ b/viewer/measures/lvp_rubefacients/vmps.sql
@@ -4,7 +4,7 @@ SELECT DISTINCT
 FROM viewer_vmp vmp
 INNER JOIN viewer_vtm vtm ON vtm.id = vmp.vtm_id
 WHERE 
-    vmp.bnf_code IN ('1003020', '10030200') -- Rubefacients, topical NSAIDS, capsaicin and poultice
+    vmp.bnf_code = '1003020' -- Rubefacients, topical NSAIDS, capsaicin and poultice
     AND 
     vtm.vtm NOT IN 
         (

--- a/viewer/tests/test_api.py
+++ b/viewer/tests/test_api.py
@@ -494,3 +494,37 @@ class TestValidateAnalysisParamsVmpCap:
         data = response.json()
         assert data["errors"] == []
         assert data["vmp_count"] == 5
+
+
+@pytest.mark.django_db
+class TestGetProductDetails:
+    def test_returns_bnf_code_for_vmp(self, client, vmp):
+        vmp.bnf_code = "0501013"
+        vmp.save(update_fields=["bnf_code"])
+
+        response = client.post(
+            reverse("viewer:get_product_details"),
+            data=json.dumps({"names": [{"code": vmp.code, "type": "vmp"}]}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        products = response.json()
+        assert len(products) == 1
+        assert products[0]["vmp_code"] == vmp.code
+        assert products[0]["bnf_code"] == "0501013"
+
+    def test_returns_null_bnf_code_when_missing(self, client, vmp):
+        vmp.bnf_code = None
+        vmp.save(update_fields=["bnf_code"])
+
+        response = client.post(
+            reverse("viewer:get_product_details"),
+            data=json.dumps({"names": [{"code": vmp.code, "type": "vmp"}]}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        products = response.json()
+        assert len(products) == 1
+        assert products[0]["bnf_code"] is None

--- a/viewer/views/api.py
+++ b/viewer/views/api.py
@@ -757,6 +757,7 @@ def build_single_product_data(vmp, quantity_data):
         'vmp_code': vmp.code,
         'vtm_name': vmp.vtm.name if vmp.vtm else None,
         'vtm_code': vmp.vtm.vtm if vmp.vtm else None,
+        'bnf_code': vmp.bnf_code,
         'routes': [route.name for route in vmp.ont_form_routes.all()],
         'who_routes': [route.name for route in vmp.who_routes.all()] if ddd_logic else [],
         'atc_codes': [atc.code for atc in vmp.atcs.all()],


### PR DESCRIPTION
Some of the BNF codes in the dm+d supplementary data have a zero-padded subparagraph. 

This strips the zero on import so that the codes are inline with expectations. It also exposes the BNF code in the product lookup and removes 8 char bnf matching in the rubefacients measure.

Resolves #911 