### PR TITLE
Improve scoped analyses

### DIFF
--- a/src/components/analyse/analyse/AnalysisBuilder.svelte
+++ b/src/components/analyse/analyse/AnalysisBuilder.svelte
@@ -86,11 +86,9 @@
     $: selectedMode = $modeSelectorStore.selectedMode;
     $: showPercentiles = $resultsStore.showPercentiles;
     $: effectiveMode = normaliseMode(selectedMode) || urlState.mode;
-    $: trustsForUrl = selectedScope === ANALYSIS_SCOPE.TRUST
-        ? selectedTrusts
-        : (isAggregationChartMode(effectiveMode)
-            ? []
-            : (isAuth ? resultsOverlayTrusts : selectedTrusts));
+    $: trustsForUrl = isAggregationChartMode(effectiveMode)
+        ? []
+        : (isAuth ? resultsOverlayTrusts : selectedTrusts);
 
     $: urlState.excludedVmps = Array.isArray($resultsStore.excludedVmps)
         ? Array.from(new Set($resultsStore.excludedVmps.filter(Boolean).map(String))).sort()
@@ -119,8 +117,7 @@
         const currentShowPercentiles = getShowPercentilesParam(
             effectiveMode,
             trustsForUrl,
-            showPercentiles,
-            selectedScope
+            showPercentiles
         );
         writeAnalysisUrlParams({
             products: selectedVMPs,
@@ -264,10 +261,9 @@
 
             urlState.excludedVmps = excludedVmps;
 
-            const overlayFromUrl = hydrateScope === ANALYSIS_SCOPE.TRUST
-                ? (patch.selectedOrganisations || []).slice(0, 1)
-                : (patch.selectedOrganisations || []);
-            await runAnalysis({ overlayOrganisations: overlayFromUrl });
+            await runAnalysis({
+                overlayOrganisations: patch.selectedOrganisations || [],
+            });
         } catch (error) {
             console.error('Failed to hydrate analysis selections from URL:', error);
         } finally {
@@ -385,7 +381,6 @@
         const validationError = validateAnalysisRun({
             selectedVMPs,
             selectedScope: runScope,
-            selectedTrusts,
             selectedScopeFilters: runScopeFilters,
             availableItems: $organisationSearchStore.availableItems || [],
         });
@@ -405,10 +400,8 @@
 
         const plan = buildAnalysisRunPlan({
             selectedScope: runScope,
-            selectedItems: $organisationSearchStore.selectedItems || [],
             availableItems: $organisationSearchStore.availableItems || [],
             allItems: $organisationSearchStore.items || [],
-            selectedTrusts,
             getOrgCode: (name) => organisationSearchStore.getOrgCode(name),
             overlayOrganisations: legacyOverlayOrganisations,
         });
@@ -417,8 +410,7 @@
             window.plausible('Analysis Run', {
                 props: {
                     all_products: selectedVMPs.map(p => p.code).join(','),
-                    // Names only for single-trust; larger cohorts are counted via organisation_count.
-                    all_organisations: runScope === ANALYSIS_SCOPE.TRUST ? plan.cohortTrusts.join(',') : '',
+                    all_organisations: '',
                     product_count: selectedVMPs.length.toString(),
                     organisation_count: plan.cohortTrusts.length.toString(),
                     search_type: searchType,
@@ -505,16 +497,12 @@
     function handleScopeChange(scope) {
         selectedScope = scope;
 
-        if (
-            scope === ANALYSIS_SCOPE.ALL
-            || scope === ANALYSIS_SCOPE.NATIONAL
-            || scope === ANALYSIS_SCOPE.TRUST
-        ) {
+        if (scope === ANALYSIS_SCOPE.ALL || scope === ANALYSIS_SCOPE.NATIONAL) {
             organisationSearchStore.setAvailableItems(Array.from($organisationSearchStore.items || []));
             organisationSearchStore.setFiltersApplied(false);
         }
 
-        if (scope === ANALYSIS_SCOPE.TRUST || scope === ANALYSIS_SCOPE.GROUP) {
+        if (scope === ANALYSIS_SCOPE.GROUP) {
             organisationSearchStore.setFilterType('trust');
         }
 

--- a/src/components/analyse/analyse/AnalysisScopePanel.svelte
+++ b/src/components/analyse/analyse/AnalysisScopePanel.svelte
@@ -44,7 +44,7 @@
 <div class="space-y-3">
   <h3 class="text-base sm:text-lg font-semibold text-oxford">Scope</h3>
   <p class="text-sm text-oxford">
-    The scope of an analysis specifies the NHS trusts to be included and the level of reporting. See <a href="/faq/#what-is-analysis-scope" class="underline font-semibold" target="_blank">the FAQs</a> for more details.
+    Choose which NHS trusts to include, and the level of reporting. See <a href="/faq/#what-is-analysis-scope" class="underline font-semibold" target="_blank">the FAQs</a> for more details.
   </p>
   <div class="relative min-w-0 max-w-full {selectedScope === ANALYSIS_SCOPE.GROUP ? 'overflow-visible' : 'overflow-x-hidden'}">
     <TrustScopePanel

--- a/src/components/analyse/analyse/AnalysisScopePanel.svelte
+++ b/src/components/analyse/analyse/AnalysisScopePanel.svelte
@@ -1,7 +1,6 @@
 <svelte:options runes={false} />
 
 <script>
-    import OrganisationSearch from '../../common/OrganisationSearch.svelte';
     import TrustScopePanel from '../../common/TrustScopePanel.svelte';
     import {
         ANALYSIS_SCOPE,
@@ -28,21 +27,15 @@
         }).orgList.length;
     }
 
-    $: selectedTrustName = selectedScope === ANALYSIS_SCOPE.TRUST
-        ? (($source.selectedItems || [])[0] || null)
-        : null;
-    $: trustCount = selectedScope === ANALYSIS_SCOPE.TRUST
-        ? ($source.selectedItems || []).length
-        : selectedScope === ANALYSIS_SCOPE.GROUP
-            ? countGroupTrusts($source, selectedScopeFilters)
-            : ($source.items || []).length;
+    $: trustCount = selectedScope === ANALYSIS_SCOPE.GROUP
+        ? countGroupTrusts($source, selectedScopeFilters)
+        : ($source.items || []).length;
     $: filterDescription = selectedScope === ANALYSIS_SCOPE.GROUP
         ? formatScopeFilterDescription(selectedScopeFilters)
         : '';
     $: scopeSummary = formatBuilderScopeSummary({
         scope: selectedScope,
         trustCount,
-        selectedTrustName,
         hasFilters: hasAnyScopeFilters(selectedScopeFilters),
         filterDescription,
     });
@@ -53,7 +46,7 @@
   <p class="text-sm text-oxford">
     The scope of an analysis specifies the NHS trusts to be included and the level of reporting. See <a href="/faq/#what-is-analysis-scope" class="underline font-semibold" target="_blank">the FAQs</a> for more details.
   </p>
-  <div class="relative min-w-0 max-w-full {selectedScope === ANALYSIS_SCOPE.TRUST || selectedScope === ANALYSIS_SCOPE.GROUP ? 'overflow-visible' : 'overflow-x-hidden'}">
+  <div class="relative min-w-0 max-w-full {selectedScope === ANALYSIS_SCOPE.GROUP ? 'overflow-visible' : 'overflow-x-hidden'}">
     <TrustScopePanel
       {source}
       {selectedScope}
@@ -61,20 +54,7 @@
       initialFilters={selectedScopeFilters}
       on:scopeChange
       on:filtersChange
-    >
-      {#snippet singleTrust()}
-        <div class="relative min-w-0 w-full z-[1000]">
-          <OrganisationSearch
-            {source}
-            overlayMode={true}
-            on:selectionChange
-            maxItems={1}
-            hideSelectAll={true}
-            showTitle={false}
-          />
-        </div>
-      {/snippet}
-    </TrustScopePanel>
+    />
   </div>
   {#if scopeSummary}
     <p class="text-sm text-gray-600">{scopeSummary}</p>

--- a/src/components/analyse/analyse/AnalysisScopePanel.svelte
+++ b/src/components/analyse/analyse/AnalysisScopePanel.svelte
@@ -2,43 +2,11 @@
 
 <script>
     import TrustScopePanel from '../../common/TrustScopePanel.svelte';
-    import {
-        ANALYSIS_SCOPE,
-        formatBuilderScopeSummary,
-        formatScopeFilterDescription,
-    } from '../lib/analysisScope.js';
-    import { applyScopeFiltersToSource, hasAnyScopeFilters } from '../../../utils/scopeFilters.js';
+    import { ANALYSIS_SCOPE } from '../lib/analysisScope.js';
 
     export let selectedScope = 'all';
     export let selectedScopeFilters = {};
     export let source;
-
-    function countGroupTrusts(store, filters) {
-        if (!hasAnyScopeFilters(filters)) {
-            return (store.items || []).length;
-        }
-        return applyScopeFiltersToSource({
-            allItems: store.items || [],
-            filters,
-            getTrustType: (name) => source.getTrustType(name),
-            getOrgsByRegionsOrICBs: (regions, icbs) => source.getOrgsByRegionsOrICBs(regions, icbs),
-            getOrgsByCancerAlliances: (alliances) => source.getOrgsByCancerAlliances(alliances),
-            orgShelfordGroup: store.orgShelfordGroup,
-        }).orgList.length;
-    }
-
-    $: trustCount = selectedScope === ANALYSIS_SCOPE.GROUP
-        ? countGroupTrusts($source, selectedScopeFilters)
-        : ($source.items || []).length;
-    $: filterDescription = selectedScope === ANALYSIS_SCOPE.GROUP
-        ? formatScopeFilterDescription(selectedScopeFilters)
-        : '';
-    $: scopeSummary = formatBuilderScopeSummary({
-        scope: selectedScope,
-        trustCount,
-        hasFilters: hasAnyScopeFilters(selectedScopeFilters),
-        filterDescription,
-    });
 </script>
 
 <div class="space-y-3">
@@ -56,7 +24,4 @@
       on:filtersChange
     />
   </div>
-  {#if scopeSummary}
-    <p class="text-sm text-gray-600">{scopeSummary}</p>
-  {/if}
 </div>

--- a/src/components/analyse/lib/analyseData.js
+++ b/src/components/analyse/lib/analyseData.js
@@ -1140,11 +1140,7 @@ export class ViewModeCalculator {
             modes.push({ value: 'region', label: 'Region' });
         }
         
-        if (
-            this.scope !== ANALYSIS_SCOPE.TRUST &&
-            national &&
-            Object.keys(national).length > 0
-        ) {
+        if (national && Object.keys(national).length > 0) {
             modes.push({ value: 'national', label: getNationalModeLabel(this.scope) });
         }
 

--- a/src/components/analyse/lib/analyseUrlParams.js
+++ b/src/components/analyse/lib/analyseUrlParams.js
@@ -68,8 +68,8 @@ export function encodeQuantityType(quantityType) {
     return QUANTITY_TYPE_CODES[trimmed] || null;
 }
 
-export function getShowPercentilesParam(mode, trusts, showPercentilesValue, scope = 'all') {
-    if (scope === ANALYSIS_SCOPE.TRUST || mode !== 'trust') return null;
+export function getShowPercentilesParam(mode, trusts, showPercentilesValue) {
+    if (mode !== 'trust') return null;
     const hasTrusts = Array.isArray(trusts) && trusts.length > 0;
     if (hasTrusts && showPercentilesValue === true) return 'true';
     return null;
@@ -310,8 +310,7 @@ export function planAnalysisHydrate({
 
     const rawShowPercentiles = urlParams.get(ANALYSIS_PERCENTILES_PARAM);
     const showPercentilesRaw =
-        scope === ANALYSIS_SCOPE.TRUST ||
-        (rawShowPercentiles?.toLowerCase() === 'true' && mode !== 'trust')
+        rawShowPercentiles?.toLowerCase() === 'true' && mode !== 'trust'
             ? null
             : rawShowPercentiles;
 
@@ -344,19 +343,17 @@ export function planValidationStorePatch({
         : [];
 
     const stashTrustsForAggregation =
-        scope !== ANALYSIS_SCOPE.TRUST &&
         hasExplicitTrustSelection &&
         isAggregationChartMode(mode);
 
-    const selectedOrganisations = scope === ANALYSIS_SCOPE.TRUST
-        ? hydratedTrustNames.slice(0, 1)
-        : (hasExplicitTrustSelection && !stashTrustsForAggregation ? hydratedTrustNames : []);
+    const selectedOrganisations = hasExplicitTrustSelection && !stashTrustsForAggregation
+        ? hydratedTrustNames
+        : [];
 
     const rememberedOverlayOrganisations = stashTrustsForAggregation
         ? hydratedTrustNames
-        : (scope !== ANALYSIS_SCOPE.TRUST && hasExplicitTrustSelection ? hydratedTrustNames : []);
+        : (hasExplicitTrustSelection ? hydratedTrustNames : []);
 
-    const organisationSelection = scope === ANALYSIS_SCOPE.TRUST ? selectedOrganisations : [];
     const hasValidTrusts = selectedOrganisations.length > 0;
     const excludedVmps = Array.isArray(data?.excluded_vmps)
         ? Array.from(new Set(data.excluded_vmps.map(String).filter(Boolean))).sort()
@@ -378,7 +375,6 @@ export function planValidationStorePatch({
         quantityType: data?.quantity_type || null,
         selectedOrganisations,
         rememberedOverlayOrganisations,
-        organisationSelection,
         showPercentiles,
         excludedVmps,
         mode: mode || null,
@@ -387,7 +383,6 @@ export function planValidationStorePatch({
 
 export function applyHydrateStorePatch(patch, {
     analyseOptions,
-    organisationSearchStore,
     resultsStore,
     modeSelectorStore,
 } = {}) {
@@ -400,7 +395,6 @@ export function applyHydrateStorePatch(patch, {
         }));
     }
 
-    organisationSearchStore.updateSelection(patch.organisationSelection);
     analyseOptions.setSelectedOrganisations(patch.selectedOrganisations);
     analyseOptions.setRememberedOverlayOrganisations(patch.rememberedOverlayOrganisations);
     resultsStore.update(store => ({
@@ -428,7 +422,6 @@ export async function finishValidatedHydrate({
 } = {}) {
     applyHydrateStorePatch(patch, {
         analyseOptions,
-        organisationSearchStore,
         resultsStore,
         modeSelectorStore,
     });

--- a/src/components/analyse/lib/analysisScope.js
+++ b/src/components/analyse/lib/analysisScope.js
@@ -3,7 +3,6 @@ import { cancerAllianceDisplayName } from '../../../utils/scopeFilters.js';
 export const ANALYSIS_SCOPE = {
     ALL: 'all',
     NATIONAL: 'national',
-    TRUST: 'trust',
     GROUP: 'group',
 };
 
@@ -46,7 +45,6 @@ export function normaliseScope(scopeValue) {
 }
 
 export function resolveAnalysisCohort(scope, {
-    selectedItems = [],
     availableItems = [],
     allItems = [],
 } = {}) {
@@ -54,9 +52,6 @@ export function resolveAnalysisCohort(scope, {
 
     if (normalisedScope === ANALYSIS_SCOPE.GROUP) {
         return Array.from(availableItems || []);
-    }
-    if (normalisedScope === ANALYSIS_SCOPE.TRUST) {
-        return (selectedItems || []).slice(0, 1);
     }
     if (normalisedScope === ANALYSIS_SCOPE.NATIONAL) {
         return [];
@@ -67,7 +62,6 @@ export function resolveAnalysisCohort(scope, {
 export function formatBuilderScopeSummary({
     scope,
     trustCount = 0,
-    selectedTrustName = null,
     hasFilters = false,
     filterDescription = '',
 } = {}) {
@@ -80,13 +74,6 @@ export function formatBuilderScopeSummary({
             return `This analysis will include all ${trustCount} trusts.`;
         case ANALYSIS_SCOPE.NATIONAL:
             return `This analysis will report national totals across ${trustCount} trust${trustCount === 1 ? '' : 's'}.`;
-        case ANALYSIS_SCOPE.TRUST: {
-            const trustName = (selectedTrustName || '').trim();
-            if (!trustName) {
-                return 'No trust selected.';
-            }
-            return `This analysis will include 1 trust: ${trustName}.`;
-        }
         case ANALYSIS_SCOPE.GROUP: {
             if (!hasFilters) {
                 return null;
@@ -101,19 +88,11 @@ export function formatBuilderScopeSummary({
     }
 }
 
-export function getScopedTrustCodes(scope, selectedTrustNames = [], {
+export function getScopedTrustCodes(scope, {
     getOrgCode,
     availableItems = [],
 } = {}) {
     const normalisedScope = normaliseScope(scope);
-    const uniqueSelectedTrusts = Array.from(new Set((selectedTrustNames || []).filter(Boolean)));
-    const selectedTrustCodes = uniqueSelectedTrusts
-        .map(name => getOrgCode?.(name))
-        .filter(Boolean);
-
-    if (normalisedScope === ANALYSIS_SCOPE.TRUST) {
-        return selectedTrustCodes;
-    }
 
     if (normalisedScope === ANALYSIS_SCOPE.GROUP) {
         return Array.from(new Set(
@@ -126,14 +105,9 @@ export function getScopedTrustCodes(scope, selectedTrustNames = [], {
     return [];
 }
 
-export function resolveNextOverlaySelection(scope, {
-    selectedItems = [],
+export function resolveNextOverlaySelection({
     overlayOrganisations,
 } = {}) {
-    const normalisedScope = normaliseScope(scope);
-    if (normalisedScope === ANALYSIS_SCOPE.TRUST) {
-        return (selectedItems || []).slice(0, 1);
-    }
     if (Array.isArray(overlayOrganisations)) {
         return overlayOrganisations;
     }
@@ -141,7 +115,7 @@ export function resolveNextOverlaySelection(scope, {
 }
 
 export function isNarrowedAnalysisScope(scope) {
-    return scope === ANALYSIS_SCOPE.TRUST || scope === ANALYSIS_SCOPE.GROUP;
+    return normaliseScope(scope) === ANALYSIS_SCOPE.GROUP;
 }
 
 export function getNationalModeLabel(scope, { longForm = false } = {}) {
@@ -165,8 +139,7 @@ export function buildAnalysisRequestPayload({
 
 export function arePercentilesDisabled(scope, trustCount = 0) {
     const normalisedScope = normaliseScope(scope);
-    return normalisedScope === ANALYSIS_SCOPE.TRUST
-        || (normalisedScope === ANALYSIS_SCOPE.GROUP && trustCount < TRUST_PERCENTILE_MIN_COUNT);
+    return normalisedScope === ANALYSIS_SCOPE.GROUP && trustCount < TRUST_PERCENTILE_MIN_COUNT;
 }
 
 export function computePercentileScopeConstraints({
@@ -238,9 +211,6 @@ function getDefaultTrustPopulationPhrase(scope, scopeDetails = {}) {
             includeArticle: false
         });
     }
-    if (scope === ANALYSIS_SCOPE.TRUST) {
-        return 'the selected NHS Trust';
-    }
     return 'all NHS Trusts in England';
 }
 
@@ -259,9 +229,6 @@ function getChartTrustContext(scope, {
     }
     if (scope === ANALYSIS_SCOPE.GROUP) {
         return `${preposition} ${formatInScopePopulationPhrase({ trustCount, filterDescription })}`;
-    }
-    if (scope === ANALYSIS_SCOPE.TRUST) {
-        return `${preposition} the selected NHS Trust`;
     }
     return `${preposition} all NHS Trusts`;
 }
@@ -428,9 +395,6 @@ export function getChartExplainerText(mode, options = {}) {
             if (resolvedScope === ANALYSIS_SCOPE.GROUP) {
                 return `This chart shows the total quantities over time across ${inScopePopulation}.`;
             }
-            if (resolvedScope === ANALYSIS_SCOPE.TRUST) {
-                return "This chart shows the total quantities over time for your selected NHS Trust.";
-            }
             return `This chart shows the total national quantities over time, combining data from ${defaultPopulation}.`;
         },
 
@@ -520,9 +484,6 @@ export function getTableExplainerText(mode, options = {}) {
 
     const baseExplainers = {
         'trust': () => {
-            if (resolvedScope === ANALYSIS_SCOPE.TRUST) {
-                return `This table shows the total quantities of the selected products issued by your selected NHS Trust ${periodText}.`;
-            }
             if (hasSelectedTrusts) {
                 if (singleSelectedTrust) {
                     return `This table shows the total quantities of the selected products issued by NHS trust ${periodText}. Data is grouped into "Selected trust" and "${otherTrustsLabel}", allowing you to compare your selected NHS Trust against others${filteredAmongSuffix}.`;
@@ -552,9 +513,6 @@ export function getTableExplainerText(mode, options = {}) {
         'national': () => {
             if (resolvedScope === ANALYSIS_SCOPE.GROUP) {
                 return `This table shows the total quantity of the selected products issued by ${inScopePopulation} ${periodText}.`;
-            }
-            if (resolvedScope === ANALYSIS_SCOPE.TRUST) {
-                return `This table shows the total quantity of the selected products issued by your selected NHS Trust ${periodText}.`;
             }
             return `This table shows the total national quantity of the selected products issued across ${defaultPopulation} ${periodText}.`;
         },

--- a/src/components/analyse/lib/analysisScope.js
+++ b/src/components/analyse/lib/analysisScope.js
@@ -167,10 +167,12 @@ export function formatInScopePopulationPhrase({
 } = {}) {
     const hasCount = Number.isFinite(trustCount) && trustCount > 0;
     const trustNoun = hasCount
-        ? (trustCount === 1 ? '1 trust' : `${trustCount} trusts`)
+        ? (trustCount === 1 ? '<strong>1 trust</strong>' : `<strong>${trustCount} trusts</strong>`)
         : 'trusts';
     const article = includeArticle && hasCount ? 'the ' : '';
-    const filterSuffix = filterDescription ? ` (${filterDescription})` : '';
+    const filterSuffix = filterDescription
+        ? ` (<strong>${filterDescription}</strong>)`
+        : '';
     return `${article}${trustNoun} in the scope for this analysis${filterSuffix}`;
 }
 
@@ -190,10 +192,15 @@ function getChartTrustContext(scope, {
     selectedTrustLabel,
     preposition = 'across',
     trustCount = null,
-    filterDescription = ''
+    filterDescription = '',
+    inScopePopulation = '',
 } = {}) {
     if (hasSelectedOrganisations) {
-        return `${preposition} the ${selectedTrustLabel}`;
+        const selectedContext = `${preposition} the ${selectedTrustLabel}`;
+        if (scope === ANALYSIS_SCOPE.GROUP && inScopePopulation) {
+            return `${selectedContext} among ${inScopePopulation}`;
+        }
+        return selectedContext;
     }
     if (scope === ANALYSIS_SCOPE.NATIONAL) {
         return 'nationally';
@@ -211,6 +218,7 @@ function createScopeCopyContext({
     hasSelectedOrganisations = false,
     selectedOrganisationsCount = 0,
 } = {}) {
+    const resolvedScope = normaliseScope(scope);
     const scopeDetails = {
         trustCount: inScopeTrustCount,
         filterDescription: scopeFilterDescription,
@@ -219,30 +227,32 @@ function createScopeCopyContext({
         trustCount: inScopeTrustCount,
         filterDescription: scopeFilterDescription,
     });
-    const defaultPopulation = getDefaultTrustPopulationPhrase(scope, scopeDetails);
+    const defaultPopulation = getDefaultTrustPopulationPhrase(resolvedScope, scopeDetails);
     const singleSelectedTrust = hasSelectedOrganisations && selectedOrganisationsCount === 1;
     const selectedTrustLabel = singleSelectedTrust ? 'selected NHS Trust' : 'selected NHS Trusts';
     const selectedTrustsPhrase = singleSelectedTrust
         ? 'your selected NHS Trust'
         : `your ${selectedOrganisationsCount} selected NHS Trusts`;
-    const otherTrustsLabel = scope === ANALYSIS_SCOPE.GROUP
+    const otherTrustsLabel = resolvedScope === ANALYSIS_SCOPE.GROUP
         ? 'All other in-scope trusts'
         : 'All other trusts';
-    const productTrustContext = getChartTrustContext(scope, {
+    const productTrustContext = getChartTrustContext(resolvedScope, {
         hasSelectedOrganisations,
         selectedTrustLabel,
         preposition: 'across',
+        inScopePopulation,
         ...scopeDetails,
     });
-    const groupedTrustContext = getChartTrustContext(scope, {
+    const groupedTrustContext = getChartTrustContext(resolvedScope, {
         hasSelectedOrganisations,
         selectedTrustLabel,
         preposition: hasSelectedOrganisations ? 'within' : 'across',
+        inScopePopulation,
         ...scopeDetails,
     });
 
     return {
-        scope,
+        scope: resolvedScope,
         scopeDetails,
         inScopePopulation,
         defaultPopulation,
@@ -255,16 +265,15 @@ function createScopeCopyContext({
     };
 }
 
-function formatListForSentence(items) {
-    if (items.length === 1) return items[0];
-    if (items.length === 2) return `${items[0]} and ${items[1]}`;
-    return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+function formatFilterGroup(labelSingular, labelPlural, values) {
+    if (!values.length) return null;
+    const label = values.length === 1 ? labelSingular : labelPlural;
+    return `${label}: ${values.join(', ')}`;
 }
 
 export function formatScopeFilterDescription(scopeFilters = {}) {
-    const parts = [];
     const trustTypes = Array.isArray(scopeFilters.trustTypes)
-        ? scopeFilters.trustTypes.map(String).filter(Boolean)
+        ? scopeFilters.trustTypes.map(String).filter(Boolean).map((type) => type.toLowerCase())
         : [];
     const regions = Array.isArray(scopeFilters.regions)
         ? scopeFilters.regions.map(String).filter(Boolean)
@@ -276,34 +285,17 @@ export function formatScopeFilterDescription(scopeFilters = {}) {
         ? scopeFilters.cancerAlliances.map(String).filter(Boolean).map(cancerAllianceDisplayName)
         : [];
 
-    if (trustTypes.length === 1) {
-        parts.push(`${trustTypes[0]} trusts`);
-    } else if (trustTypes.length > 1) {
-        parts.push(`trust types ${formatListForSentence(trustTypes)}`);
-    }
-
-    if (regions.length === 1) {
-        parts.push(`${regions[0]} region`);
-    } else if (regions.length > 1) {
-        parts.push(`regions ${formatListForSentence(regions)}`);
-    }
-
-    if (icbs.length === 1) {
-        parts.push(icbs[0]);
-    } else if (icbs.length > 1) {
-        parts.push(`ICBs ${formatListForSentence(icbs)}`);
-    }
-
-    if (cancerAlliances.length === 1) {
-        parts.push(`${cancerAlliances[0]} cancer alliance`);
-    } else if (cancerAlliances.length > 1) {
-        parts.push(`cancer alliances ${formatListForSentence(cancerAlliances)}`);
-    }
+    const parts = [
+        formatFilterGroup('trust type', 'trust types', trustTypes),
+        formatFilterGroup('region', 'regions', regions),
+        formatFilterGroup('ICB', 'ICBs', icbs),
+        formatFilterGroup('cancer alliance', 'cancer alliances', cancerAlliances),
+    ].filter(Boolean);
 
     if (scopeFilters.shelford === 'in') {
-        parts.push('Shelford Group trusts');
+        parts.push('Shelford Group: included');
     } else if (scopeFilters.shelford === 'not_in') {
-        parts.push('trusts outside the Shelford Group');
+        parts.push('Shelford Group: excluded');
     }
 
     return parts.join('; ');
@@ -334,22 +326,26 @@ export function getChartExplainerText(mode, options = {}) {
         selectedOrganisationsCount,
     });
 
+    const selectedAmongScopeSuffix = resolvedScope === ANALYSIS_SCOPE.GROUP
+        ? ` among ${inScopePopulation}`
+        : '';
+
     const baseExplainers = {
         'trust': () => {
             if (hasSelectedOrganisations) {
                 if (currentModeHasData) {
                     if (singleSelectedTrust) {
-                        return "This chart shows quantities over time for your selected NHS Trust.";
+                        return `This chart shows quantities over time for your selected NHS Trust${selectedAmongScopeSuffix}.`;
                     }
-                    return "This chart shows individual NHS Trust quantities over time for your selected trusts. Each line represents one trust, allowing you to compare their usage patterns.";
+                    return `This chart shows individual NHS Trust quantities over time for your selected trusts${selectedAmongScopeSuffix}. Each line represents one trust, allowing you to compare their usage patterns.`;
                 }
                 if (singleSelectedTrust) {
-                    return "This chart would show NHS Trust quantities, but the selected trust has no data for these products.";
+                    return `This chart would show NHS Trust quantities${selectedAmongScopeSuffix}, but the selected trust has no data for these products.`;
                 }
-                return "This chart would show individual NHS Trust quantities, but the selected trusts have no data for these products.";
+                return `This chart would show individual NHS Trust quantities${selectedAmongScopeSuffix}, but the selected trusts have no data for these products.`;
             }
             if (resolvedScope === ANALYSIS_SCOPE.GROUP) {
-                return `This chart shows individual NHS Trust quantities over time. Each line represents one trust in the scope for this analysis, allowing you to compare usage patterns across ${inScopePopulation}.`;
+                return `This chart shows individual NHS Trust quantities over time. Each line represents one trust, allowing you to compare usage patterns across ${inScopePopulation}.`;
             }
             return "This chart shows individual NHS Trust quantities over time. Each line represents one trust, allowing you to compare usage patterns across different trusts.";
         },
@@ -490,28 +486,28 @@ export function getTableExplainerText(mode, options = {}) {
 
         'product': () => {
             if (hasSelectedTrusts) {
-                return `This table shows the total quantities of each of the selected products issued ${periodText}, filtered to only include data from ${selectedTrustsPhrase}.`;
+                return `This table shows the total quantities of each of the selected products issued ${periodText}, filtered to only include data from ${selectedTrustsPhrase}${filteredAmongSuffix}.`;
             }
             return `This table shows the total quantities of each of the selected products issued ${periodText}, across ${defaultPopulation}.`;
         },
 
         'productGroup': () => {
             if (hasSelectedTrusts) {
-                return `This table shows the total quantities of the selected products issued by product group ${periodText}, filtered to only include data from ${selectedTrustsPhrase}.`;
+                return `This table shows the total quantities of the selected products issued by product group ${periodText}, filtered to only include data from ${selectedTrustsPhrase}${filteredAmongSuffix}.`;
             }
             return `This table shows the total quantities of the selected products issued by product group ${periodText} across ${defaultPopulation}.`;
         },
 
         'ingredient': () => {
             if (hasSelectedTrusts) {
-                return `This table shows total quantities by active ingredient ${periodText}, filtered to only include data from ${selectedTrustsPhrase}.`;
+                return `This table shows total quantities by active ingredient ${periodText}, filtered to only include data from ${selectedTrustsPhrase}${filteredAmongSuffix}.`;
             }
             return `This table shows total quantities by active ingredient ${periodText} across ${defaultPopulation}.`;
         },
 
         'unit': () => {
             if (hasSelectedTrusts) {
-                return `This table shows total quantities by unit of measurement ${periodText}, filtered to only include data from ${selectedTrustsPhrase}.`;
+                return `This table shows total quantities by unit of measurement ${periodText}, filtered to only include data from ${selectedTrustsPhrase}${filteredAmongSuffix}.`;
             }
             return `This table shows total quantities by unit of measurement ${periodText} across ${defaultPopulation}.`;
         }
@@ -529,23 +525,19 @@ export function getPercentileChartIntroText({
     selectedOrganisationsCount = 0,
     currentModeHasData = true,
     singleSelectedTrust = false,
-    isFilteredScope = false,
     percentilePopulationLabel = 'all NHS Trusts',
 } = {}) {
-    const trustScope = isFilteredScope ? 'in-scope trusts' : 'all trusts';
-
     if (selectedOrganisationsCount <= 0) {
-        const bandScope = isFilteredScope ? 'trusts in scope' : 'trusts';
-        return `This chart shows percentile ranges across ${percentilePopulationLabel} with data for the selected products. The bands represent the variation in quantities across ${bandScope}.`;
+        return `This chart shows percentile ranges across ${percentilePopulationLabel} with data for the selected products. The bands represent the variation in quantities across those trusts.`;
     }
 
     if (currentModeHasData) {
         return singleSelectedTrust
-            ? `This chart shows the selected NHS Trust quantity overlaid on percentile ranges. The selected trust appears as a coloured line, while percentile bands show the distribution across ${trustScope} with data.`
-            : `This chart shows individual NHS Trust quantities overlaid on percentile ranges. Selected trusts appear as coloured lines, while percentile bands show the distribution across ${trustScope} with data.`;
+            ? `This chart shows the selected NHS Trust quantity overlaid on percentile ranges. The selected trust appears as a coloured line, while percentile bands show the distribution across ${percentilePopulationLabel} with data.`
+            : `This chart shows individual NHS Trust quantities overlaid on percentile ranges. Selected trusts appear as coloured lines, while percentile bands show the distribution across ${percentilePopulationLabel} with data.`;
     }
 
     return singleSelectedTrust
-        ? `This chart shows percentile ranges across ${percentilePopulationLabel} with data. The selected trust has no data for these products, but percentile bands show the distribution across ${trustScope} with data.`
-        : `This chart shows percentile ranges across ${percentilePopulationLabel} with data. The selected trusts have no data for these products, but percentile bands show the distribution across ${trustScope} with data.`;
+        ? `This chart shows percentile ranges across ${percentilePopulationLabel} with data. The selected trust has no data for these products, but percentile bands show the distribution across ${percentilePopulationLabel} with data.`
+        : `This chart shows percentile ranges across ${percentilePopulationLabel} with data. The selected trusts have no data for these products, but percentile bands show the distribution across ${percentilePopulationLabel} with data.`;
 }

--- a/src/components/analyse/lib/analysisScope.js
+++ b/src/components/analyse/lib/analysisScope.js
@@ -59,35 +59,6 @@ export function resolveAnalysisCohort(scope, {
     return Array.from(allItems || []);
 }
 
-export function formatBuilderScopeSummary({
-    scope,
-    trustCount = 0,
-    hasFilters = false,
-    filterDescription = '',
-} = {}) {
-    const normalisedScope = normaliseScope(scope);
-    const trimmedFilterDescription = (filterDescription || '').trim();
-    const filterSuffix = trimmedFilterDescription ? ` (${trimmedFilterDescription})` : '';
-
-    switch (normalisedScope) {
-        case ANALYSIS_SCOPE.ALL:
-            return `This analysis will include all ${trustCount} trusts.`;
-        case ANALYSIS_SCOPE.NATIONAL:
-            return `This analysis will report national totals across ${trustCount} trust${trustCount === 1 ? '' : 's'}.`;
-        case ANALYSIS_SCOPE.GROUP: {
-            if (!hasFilters) {
-                return null;
-            }
-            if (trustCount <= 0) {
-                return `No trusts match these filters${filterSuffix}.`;
-            }
-            return `This selection will analyse ${trustCount} trust${trustCount === 1 ? '' : 's'}${filterSuffix}.`;
-        }
-        default:
-            return null;
-    }
-}
-
 export function getScopedTrustCodes(scope, {
     getOrgCode,
     availableItems = [],

--- a/src/components/analyse/lib/runAnalysis.js
+++ b/src/components/analyse/lib/runAnalysis.js
@@ -21,7 +21,7 @@ export function validateAnalysisRun({
         return 'Please select at least one product or ingredient.';
     }
     if (selectedScope === ANALYSIS_SCOPE.GROUP && !hasAnyScopeFilters(selectedScopeFilters)) {
-        return 'Please select at least one filter to define your trust group.';
+        return 'Please select at least one filter for filtered trusts.';
     }
     if (
         selectedScope === ANALYSIS_SCOPE.GROUP

--- a/src/components/analyse/lib/runAnalysis.js
+++ b/src/components/analyse/lib/runAnalysis.js
@@ -14,15 +14,11 @@ import {
 export function validateAnalysisRun({
     selectedVMPs = [],
     selectedScope = ANALYSIS_SCOPE.ALL,
-    selectedTrusts = [],
     selectedScopeFilters = createEmptyScopeFilters(),
     availableItems = [],
 } = {}) {
     if (!selectedVMPs || selectedVMPs.length === 0) {
         return 'Please select at least one product or ingredient.';
-    }
-    if (selectedScope === ANALYSIS_SCOPE.TRUST && selectedTrusts.length === 0) {
-        return 'Please select a trust for your single-trust analysis.';
     }
     if (selectedScope === ANALYSIS_SCOPE.GROUP && !hasAnyScopeFilters(selectedScopeFilters)) {
         return 'Please select at least one filter to define your trust group.';
@@ -38,25 +34,21 @@ export function validateAnalysisRun({
 
 export function buildAnalysisRunPlan({
     selectedScope = ANALYSIS_SCOPE.ALL,
-    selectedItems = [],
     availableItems = [],
     allItems = [],
-    selectedTrusts = [],
     getOrgCode,
     overlayOrganisations,
 } = {}) {
     const cohortTrusts = resolveAnalysisCohort(selectedScope, {
-        selectedItems,
         availableItems,
         allItems,
     });
-    const odsCodes = getScopedTrustCodes(selectedScope, selectedTrusts, {
+    const odsCodes = getScopedTrustCodes(selectedScope, {
         getOrgCode,
         availableItems,
     });
     const hasExplicitOverlay = Array.isArray(overlayOrganisations);
-    const nextOverlaySelection = resolveNextOverlaySelection(selectedScope, {
-        selectedItems,
+    const nextOverlaySelection = resolveNextOverlaySelection({
         overlayOrganisations: hasExplicitOverlay ? overlayOrganisations : undefined,
     });
 
@@ -145,7 +137,7 @@ export function completeAnalysisRun({
     updateResults,
 } = {}) {
     analyseOptions.setSelectedOrganisations(plan.nextOverlaySelection);
-    if (!plan.hasExplicitOverlay && selectedScope !== ANALYSIS_SCOPE.TRUST) {
+    if (!plan.hasExplicitOverlay) {
         analyseOptions.setRememberedOverlayOrganisations([]);
     }
     analyseOptions.runAnalysis({

--- a/src/components/analyse/results/AnalysisResults.svelte
+++ b/src/components/analyse/results/AnalysisResults.svelte
@@ -96,7 +96,6 @@
     $: analysisScope = $resultsStore.scope || ANALYSIS_SCOPE.ALL;
     $: availableTrusts = Array.isArray($resultsStore.inScopeTrusts) ? $resultsStore.inScopeTrusts : [];
     $: isFilteredScope = analysisScope === ANALYSIS_SCOPE.GROUP;
-    $: isTrustScope = analysisScope === ANALYSIS_SCOPE.TRUST;
     $: scopeFilterDescription = isFilteredScope
         ? formatScopeFilterDescription($resultsStore.scopeFilters || {})
         : '';
@@ -569,12 +568,11 @@
                 <div class="space-y-2 p-6">
                     <section class="bg-white rounded-lg p-2 border-2 border-oxford-300 shadow-sm">
                         <ProductsTable {vmps} {excludedVmps} on:dataFiltered={handleFilteredData} />
-                        {#if (isFilteredScope || isTrustScope) && availableTrusts.length > 0}
+                        {#if isFilteredScope && availableTrusts.length > 0}
                             <div class="mx-4 border-t border-gray-200">
                                 <TrustsIncluded
                                     trusts={availableTrusts}
                                     filterDescription={scopeFilterDescription}
-                                    isSingleTrust={isTrustScope}
                                 />
                             </div>
                         {/if}
@@ -587,7 +585,6 @@
                             {shouldShowOrganisationSearch}
                             {availableTrusts}
                             {viewModes}
-                            {isTrustScope}
                             {percentilesDisabled}
                             {trustPercentileToggleDisabled}
                             {isCopyingShareLink}

--- a/src/components/analyse/results/AnalysisResults.svelte
+++ b/src/components/analyse/results/AnalysisResults.svelte
@@ -100,7 +100,6 @@
         ? formatScopeFilterDescription($resultsStore.scopeFilters || {})
         : '';
     $: inScopeTrustCount = availableTrusts.length;
-    $: inScopeTrustLabel = isFilteredScope ? 'in-scope trusts' : 'trusts';
     $: percentilePopulationLabel = isFilteredScope
         ? formatInScopePopulationPhrase({
             trustCount: inScopeTrustCount,
@@ -523,7 +522,6 @@
         selectedOrganisationsCount,
         currentModeHasData,
         singleSelectedTrust,
-        isFilteredScope,
         percentilePopulationLabel,
     });
 </script>
@@ -598,10 +596,10 @@
                         <div class="mb-4">
                             <p class="text-sm text-gray-700">
                                 {#if $modeSelectorStore.selectedMode === 'trust' && $resultsStore.showPercentiles}
-                                    {percentileIntroText}
+                                    {@html percentileIntroText}
                                     {#if $resultsStore.trustCount > 0}
                                         {#if isFilteredScope}
-                                            Only in-scope trusts that have issued any of the selected products during the time period are included. For the selected products above, this is <strong>{$resultsStore.trustCount}/{availableTrusts.length} {inScopeTrustLabel}</strong>
+                                            Only in-scope trusts that have issued any of the selected products during the time period are included. For the selected products above, this is <strong>{$resultsStore.trustCount}/{availableTrusts.length} in-scope trusts</strong>
                                         {:else}
                                             Trusts are only included if they have issued any of the selected products during the time period. For the selected products above, this is <strong>{$resultsStore.trustCount}/{availableTrusts.length} trusts</strong>
                                         {/if}
@@ -619,7 +617,7 @@
                                     Variation can reflect differences in hospital size rather than genuine variation.
                                     See <a href="/faq/#what-are-percentile-charts" class="underline font-semibold" target="_blank">the FAQs</a> for more details about how to interpret this chart.
                                 {:else}
-                                    {chartExplainerText}
+                                    {@html chartExplainerText}
                                     See <a href="/faq/" class="underline font-semibold" target="_blank">the FAQs</a> for more details about interpreting charts.
                                 {/if}
                             </p>

--- a/src/components/analyse/results/ResultsChartControls.svelte
+++ b/src/components/analyse/results/ResultsChartControls.svelte
@@ -13,7 +13,6 @@
     export let shouldShowOrganisationSearch = false;
     export let availableTrusts = [];
     export let viewModes = [];
-    export let isTrustScope = false;
     export let percentilesDisabled = false;
     export let trustPercentileToggleDisabled = true;
     export let isCopyingShareLink = false;
@@ -67,7 +66,7 @@
             onChange={(mode) => dispatch('modeChange', { mode })}
         />
 
-        {#if $modeSelectorStore.selectedMode === 'trust' && !isTrustScope}
+        {#if $modeSelectorStore.selectedMode === 'trust'}
             <div class="flex flex-col gap-4">
                 <div class="flex flex-col items-center gap-2">
                     <span class="text-sm text-gray-600 leading-tight text-center">

--- a/src/components/analyse/results/TotalsTable.svelte
+++ b/src/components/analyse/results/TotalsTable.svelte
@@ -16,7 +16,6 @@
         getTableExplainerText,
         formatScopeFilterDescription,
     } from '../lib/analysisScope.js';
-
     export let data = [];
     export let quantityType = 'SCMD Quantity';
     export let searchType = 'vmp';
@@ -194,7 +193,7 @@
     
     <div class="mb-4">
         <p class="text-sm text-gray-700">
-            {tableExplainerText}
+            {@html tableExplainerText}
         </p>
     </div>
     

--- a/src/components/analyse/results/TrustsIncluded.svelte
+++ b/src/components/analyse/results/TrustsIncluded.svelte
@@ -3,30 +3,20 @@
 <script>
     export let trusts = [];
     export let filterDescription = '';
-    export let isSingleTrust = false;
 
     $: trustCount = (trusts || []).length;
     $: trustLabel = trustCount === 1 ? 'trust' : 'trusts';
-    $: trustName = trustCount > 0 ? trusts[0] : '';
 </script>
 
 <div class="py-4">
     <h3 class="text-xl font-semibold mb-4">Trusts included in analysis</h3>
     <div class="mb-2 text-sm text-gray-700">
         <p>
-            {#if isSingleTrust}
-                This analysis is scoped to a single NHS trust.
-            {:else}
-                This analysis is scoped to a group of NHS trusts.
-            {/if}
+            This analysis is scoped to a group of NHS trusts.
             You can see the trusts included in the <a href="#analysis-totals-table" class="text-blue-600 hover:text-blue-800 underline">table below</a>.
         </p>
     </div>
     <p class="text-sm text-gray-600">
-        {#if isSingleTrust}
-            Included: <span class="font-semibold">{trustName}</span>
-        {:else}
-            Included: <span class="font-semibold">{trustCount}</span> {trustLabel}{#if filterDescription}{' '}({filterDescription}){/if}
-        {/if}
+        Included: <span class="font-semibold">{trustCount}</span> {trustLabel}{filterDescription ? ` (${filterDescription})` : ''}
     </p>
 </div>

--- a/src/components/analyse/results/TrustsIncluded.svelte
+++ b/src/components/analyse/results/TrustsIncluded.svelte
@@ -17,6 +17,6 @@
         </p>
     </div>
     <p class="text-sm text-gray-600">
-        Included: <span class="font-semibold">{trustCount}</span> {trustLabel}{filterDescription ? ` (${filterDescription})` : ''}
+        Included: <span class="font-semibold">{trustCount} {trustLabel}</span>{filterDescription ? ` (${filterDescription})` : ''}
     </p>
 </div>

--- a/src/components/common/OrganisationSearchFiltered.svelte
+++ b/src/components/common/OrganisationSearchFiltered.svelte
@@ -436,7 +436,11 @@
                     <button type="button" class="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-medium border transition-colors focus:outline-none focus:ring-2 focus:ring-oxford-500 focus:ring-offset-0 {disabled ? 'opacity-50 cursor-not-allowed bg-gray-100 text-gray-500 border-gray-200' : ''} {filterDropdownOpen || hasFilterSelection ? 'bg-oxford-50 text-oxford-700 border-oxford-200' : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'}" on:click={() => !disabled && (filterDropdownOpen = !filterDropdownOpen)} disabled={disabled} aria-haspopup="listbox" aria-expanded={filterDropdownOpen} aria-label="Filter by trust type, region, ICB, cancer alliance, and Shelford Group">
                         <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" /></svg>
                         <span>Filters</span>
-                        {#if hasFilterSelection}<span class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded-full text-[10px] font-medium leading-none bg-oxford-100 text-oxford-700">{filterBadgeCount}</span>{/if}
+                        {#if hasFilterSelection}
+                            <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
+                                {filterBadgeCount} filter{filterBadgeCount === 1 ? '' : 's'} selected
+                            </span>
+                        {/if}
                         <svg class="w-3.5 h-3.5 shrink-0 transition-transform {filterDropdownOpen ? 'rotate-180' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
                     </button>
                 </div>

--- a/src/components/common/TrustScopePanel.svelte
+++ b/src/components/common/TrustScopePanel.svelte
@@ -74,7 +74,6 @@
         selectedCancerAlliances.size +
         (shelfordFilter !== null ? 1 : 0);
     $: showGroupFilters = !enableScopeSelection || selectedScope === SCOPE_GROUP;
-    $: totalTrustCount = ($source.items || []).length;
 
     function stripNhsPrefix(str) {
         if (str == null || typeof str !== 'string') return '';
@@ -265,61 +264,67 @@
             {/if}
         </div>
     {/if}
-    <div class="flex-1 py-2 {enableScopeSelection && selectedScope === SCOPE_GROUP ? 'overflow-visible' : 'overflow-y-auto max-h-[min(70vh,400px)]'}">
+    <div class="flex-1 {enableScopeSelection ? '' : 'py-2'} {enableScopeSelection && selectedScope === SCOPE_GROUP ? 'overflow-visible' : 'overflow-y-auto max-h-[min(70vh,400px)]'}">
         {#if enableScopeSelection}
-            <div class="px-2 pb-2">
-                <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm transition-colors mx-1 min-h-[44px] sm:min-h-0 {selectedScope === SCOPE_ALL ? 'text-oxford-700' : 'text-gray-700'}">
-                    <input
-                        type="radio"
-                        name="trust-scope-selection"
-                        checked={selectedScope === SCOPE_ALL}
-                        on:change={() => selectScope(SCOPE_ALL)}
-                        class="border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
-                    />
-                    <span class="flex-1 min-w-0">All trusts</span>
-                    <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
-                        {totalTrustCount} trusts
+            <div class="divide-y divide-gray-100" role="radiogroup" aria-label="Analysis scope">
+                <button
+                    type="button"
+                    role="radio"
+                    aria-checked={selectedScope === SCOPE_ALL}
+                    on:click={() => selectScope(SCOPE_ALL)}
+                    class="w-full text-left px-3 py-2.5 text-sm min-h-[44px] sm:min-h-0 transition-none focus:outline-none focus:ring-2 focus:ring-inset focus:ring-oxford-500
+                        {selectedScope === SCOPE_ALL ? 'bg-oxford-100 text-oxford-700' : 'text-gray-700 hover:bg-gray-50'}"
+                >
+                    <span class="font-medium">All trusts <span class="font-normal text-gray-500">(default)</span></span>
+                    <span class="block text-xs text-gray-500 mt-0.5 leading-snug">
+                        Trust-level data for every NHS Trust. Analyse one or more trusts and compare them.
                     </span>
-                </label>
-                <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm transition-colors mx-1 min-h-[44px] sm:min-h-0 {selectedScope === SCOPE_NATIONAL ? 'text-oxford-700' : 'text-gray-700'}">
-                    <input
-                        type="radio"
-                        name="trust-scope-selection"
-                        checked={selectedScope === SCOPE_NATIONAL}
-                        on:change={() => selectScope(SCOPE_NATIONAL)}
-                        class="border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
-                    />
-                    <span class="flex-1 min-w-0">National</span>
-                    <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
-                        {totalTrustCount} trusts
+                </button>
+                <button
+                    type="button"
+                    role="radio"
+                    aria-checked={selectedScope === SCOPE_NATIONAL}
+                    on:click={() => selectScope(SCOPE_NATIONAL)}
+                    class="w-full text-left px-3 py-2.5 text-sm min-h-[44px] sm:min-h-0 transition-none focus:outline-none focus:ring-2 focus:ring-inset focus:ring-oxford-500
+                        {selectedScope === SCOPE_NATIONAL ? 'bg-oxford-100 text-oxford-700' : 'text-gray-700 hover:bg-gray-50'}"
+                >
+                    <span class="font-medium">National</span>
+                    <span class="block text-xs text-gray-500 mt-0.5 leading-snug">
+                        National totals across all NHS Trusts.
                     </span>
-                </label>
-                <div class="mx-1 flex items-center gap-2 min-h-[44px] sm:min-h-0">
-                    <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm transition-colors flex-1 min-w-0 {selectedScope === SCOPE_GROUP ? 'text-oxford-700' : 'text-gray-700'}">
-                        <input
-                            type="radio"
-                            name="trust-scope-selection"
-                            checked={selectedScope === SCOPE_GROUP}
-                            on:change={() => selectScope(SCOPE_GROUP)}
-                            class="border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
-                        />
-                        <span class="flex-1 min-w-0">Filtered trusts</span>
+                </button>
+                <div
+                    role="radio"
+                    tabindex="0"
+                    aria-checked={selectedScope === SCOPE_GROUP}
+                    on:click={() => selectScope(SCOPE_GROUP)}
+                    on:keydown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            selectScope(SCOPE_GROUP);
+                        }
+                    }}
+                    class="w-full text-left px-3 py-2.5 text-sm min-h-[44px] sm:min-h-0 transition-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-inset focus:ring-oxford-500
+                        {selectedScope === SCOPE_GROUP ? 'bg-oxford-100 text-oxford-700' : 'text-gray-700 hover:bg-gray-50'}"
+                >
+                    <div class="flex items-center gap-2 min-w-0">
+                        <span class="font-medium shrink-0">Filtered trusts</span>
                         {#if selectedScope === SCOPE_GROUP && filterBadgeCount > 0}
-                            <span class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded-full text-[10px] font-medium leading-none bg-oxford-100 text-oxford-700">{filterBadgeCount}</span>
+                            <button
+                                type="button"
+                                class="ml-auto shrink-0 text-xs font-medium text-oxford-600 hover:text-oxford-800 py-0.5 px-1.5 rounded hover:bg-white/60"
+                                on:click|stopPropagation={clearAllFilters}
+                            >
+                                Clear all
+                            </button>
                         {/if}
-                    </label>
-                    {#if selectedScope === SCOPE_GROUP && filterBadgeCount > 0}
-                        <button
-                            type="button"
-                            class="text-xs font-medium text-oxford-600 hover:text-oxford-800 py-0.5 px-1.5 rounded hover:bg-oxford-50 transition-colors shrink-0"
-                            on:click={clearAllFilters}
-                        >
-                            Clear all
-                        </button>
-                    {/if}
+                    </div>
+                    <span class="block text-xs text-gray-500 mt-0.5 leading-snug">
+                        Select a subset of trusts by geography, trust type, and more.
+                    </span>
                 </div>
                 {#if selectedScope === SCOPE_GROUP}
-                    <div class="mt-1 ml-1 pl-1.5 border-l border-gray-200 min-w-0">
+                    <div class="pt-1 pb-2 min-w-0">
                         {@render groupFilterSections()}
                     </div>
                 {/if}

--- a/src/components/common/TrustScopePanel.svelte
+++ b/src/components/common/TrustScopePanel.svelte
@@ -5,6 +5,7 @@
     import {
         ACUTE_PARENT,
         acuteSubtypeLabel,
+        applyScopeFiltersToSource,
         CANCER_ALLIANCE_NA,
         cancerAllianceDisplayName,
         hasAnyScopeFilters,
@@ -74,6 +75,53 @@
         selectedCancerAlliances.size +
         (shelfordFilter !== null ? 1 : 0);
     $: showGroupFilters = !enableScopeSelection || selectedScope === SCOPE_GROUP;
+    $: currentFilters = {
+        trustTypes: [...selectedTrustTypes].sort(),
+        regions: Array.from(selectedRegions).sort(),
+        icbs: Array.from(selectedICBs).sort(),
+        cancerAlliances: Array.from(selectedCancerAlliances).sort(),
+        shelford: shelfordFilter
+    };
+    $: groupTrustCount = !hasAnyScopeFilters(currentFilters)
+        ? 0
+        : applyScopeFiltersToSource({
+            allItems: $source.items || [],
+            filters: currentFilters,
+            getTrustType: (name) => $source.trustTypes?.get(name) ?? null,
+            getOrgsByRegionsOrICBs: (regions, icbs) => {
+                const hasRegions = regions && regions.size > 0;
+                const hasIcbs = icbs && icbs.size > 0;
+                if (!hasRegions && !hasIcbs) return [];
+                const result = new Set();
+                for (const name of $source.items || []) {
+                    if (hasRegions && regions.has($source.orgRegions?.get(name))) {
+                        result.add(name);
+                        continue;
+                    }
+                    if (hasIcbs && icbs.has($source.orgIcbs?.get(name))) {
+                        result.add(name);
+                    }
+                }
+                return Array.from(result);
+            },
+            getOrgsByCancerAlliances: (alliances) => {
+                if (!alliances || alliances.size === 0) return [];
+                const itemsSet = new Set($source.items || []);
+                const map = $source.orgCancerAlliances || new Map();
+                const result = new Set();
+                if (alliances.has(CANCER_ALLIANCE_NA)) {
+                    for (const name of $source.items || []) {
+                        const ca = map.get(name);
+                        if (!ca || ca === '') result.add(name);
+                    }
+                }
+                for (const [orgName, ca] of map) {
+                    if (ca && alliances.has(ca) && itemsSet.has(orgName)) result.add(orgName);
+                }
+                return Array.from(result);
+            },
+            orgShelfordGroup: $source.orgShelfordGroup,
+        }).orgList.length;
 
     function stripNhsPrefix(str) {
         if (str == null || typeof str !== 'string') return '';
@@ -307,15 +355,20 @@
                     class="w-full text-left px-3 py-2.5 text-sm min-h-[44px] sm:min-h-0 transition-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-inset focus:ring-oxford-500
                         {selectedScope === SCOPE_GROUP ? 'bg-oxford-100 text-oxford-700' : 'text-gray-700 hover:bg-gray-50'}"
                 >
-                    <div class="flex items-center gap-2 min-w-0">
+                    <div class="flex items-center gap-1.5 min-w-0">
                         <span class="font-medium shrink-0">Filtered trusts</span>
+                        {#if selectedScope === SCOPE_GROUP}
+                            <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums bg-white/80 px-1.5 py-0.5 rounded">
+                                {groupTrustCount} trust{groupTrustCount === 1 ? '' : 's'} selected
+                            </span>
+                        {/if}
                         {#if selectedScope === SCOPE_GROUP && filterBadgeCount > 0}
                             <button
                                 type="button"
                                 class="ml-auto shrink-0 text-xs font-medium text-oxford-600 hover:text-oxford-800 py-0.5 px-1.5 rounded hover:bg-white/60"
                                 on:click|stopPropagation={clearAllFilters}
                             >
-                                Clear all
+                                Clear selection
                             </button>
                         {/if}
                     </div>

--- a/src/components/common/TrustScopePanel.svelte
+++ b/src/components/common/TrustScopePanel.svelte
@@ -303,7 +303,7 @@
                             on:change={() => selectScope(SCOPE_GROUP)}
                             class="border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
                         />
-                        <span class="flex-1 min-w-0">Trust group</span>
+                        <span class="flex-1 min-w-0">Filtered trusts</span>
                         {#if selectedScope === SCOPE_GROUP && filterBadgeCount > 0}
                             <span class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded-full text-[10px] font-medium leading-none bg-oxford-100 text-oxford-700">{filterBadgeCount}</span>
                         {/if}

--- a/src/components/common/TrustScopePanel.svelte
+++ b/src/components/common/TrustScopePanel.svelte
@@ -68,12 +68,14 @@
     ).length;
     $: selectedTrustTypeFilterCount =
         selectedOtherTrustTypeCount + (acuteParentSelected ? 1 : selectedAcuteSubtypeCount);
+    $: regionIcbFilterCount = selectedRegions.size + selectedICBs.size;
+    $: cancerAllianceFilterCount = selectedCancerAlliances.size;
+    $: shelfordFilterCount = shelfordFilter !== null ? 1 : 0;
     $: filterBadgeCount =
         selectedTrustTypeFilterCount +
-        selectedRegions.size +
-        selectedICBs.size +
-        selectedCancerAlliances.size +
-        (shelfordFilter !== null ? 1 : 0);
+        regionIcbFilterCount +
+        cancerAllianceFilterCount +
+        shelfordFilterCount;
     $: showGroupFilters = !enableScopeSelection || selectedScope === SCOPE_GROUP;
     $: currentFilters = {
         trustTypes: [...selectedTrustTypes].sort(),
@@ -298,7 +300,9 @@
             <div class="flex items-center gap-1.5 min-w-0">
                 <span class="text-xs font-semibold text-gray-600 uppercase tracking-wide">Filter by</span>
                 {#if filterBadgeCount > 0}
-                    <span class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded-full text-[10px] font-medium leading-none bg-oxford-100 text-oxford-700">{filterBadgeCount}</span>
+                    <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums normal-case tracking-normal bg-gray-100/80 px-1.5 py-0.5 rounded">
+                        {filterBadgeCount} filter{filterBadgeCount === 1 ? '' : 's'} selected
+                    </span>
                 {/if}
             </div>
             {#if filterBadgeCount > 0}
@@ -396,7 +400,14 @@
                 class="w-full flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-gray-500 uppercase tracking-wide hover:bg-gray-50 transition-colors"
                 on:click={() => (collapsedRegionIcb = !collapsedRegionIcb)}
             >
-                <span>Region &amp; ICB</span>
+                <span class="flex items-center gap-1.5 min-w-0">
+                    <span>Region &amp; ICB</span>
+                    {#if regionIcbFilterCount > 0}
+                        <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums normal-case tracking-normal bg-gray-100/80 px-1.5 py-0.5 rounded">
+                            {regionIcbFilterCount} filter{regionIcbFilterCount === 1 ? '' : 's'} selected
+                        </span>
+                    {/if}
+                </span>
                 <svg
                     class="w-3.5 h-3.5 transition-transform duration-200 {collapsedRegionIcb ? '' : 'rotate-180'}"
                     fill="none"
@@ -505,6 +516,11 @@
                         </p>
                     </div>
                 </div>
+                {#if selectedTrustTypeFilterCount > 0}
+                    <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums normal-case tracking-normal bg-gray-100/80 px-1.5 py-0.5 rounded">
+                        {selectedTrustTypeFilterCount} filter{selectedTrustTypeFilterCount === 1 ? '' : 's'} selected
+                    </span>
+                {/if}
                 <button
                     type="button"
                     class="ml-auto flex-1 flex items-center justify-end"
@@ -626,6 +642,11 @@
                         </p>
                     </div>
                 </div>
+                {#if cancerAllianceFilterCount > 0}
+                    <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums normal-case tracking-normal bg-gray-100/80 px-1.5 py-0.5 rounded">
+                        {cancerAllianceFilterCount} filter{cancerAllianceFilterCount === 1 ? '' : 's'} selected
+                    </span>
+                {/if}
                 <button
                     type="button"
                     class="ml-auto flex-1 flex items-center justify-end"
@@ -706,6 +727,11 @@
                         </p>
                     </div>
                 </div>
+                {#if shelfordFilterCount > 0}
+                    <span class="text-[10px] font-medium text-gray-400 shrink-0 tabular-nums normal-case tracking-normal bg-gray-100/80 px-1.5 py-0.5 rounded">
+                        {shelfordFilterCount} filter{shelfordFilterCount === 1 ? '' : 's'} selected
+                    </span>
+                {/if}
                 <button
                     type="button"
                     class="ml-auto flex-1 flex items-center justify-end"

--- a/src/components/common/TrustScopePanel.svelte
+++ b/src/components/common/TrustScopePanel.svelte
@@ -507,11 +507,11 @@
                     </button>
                     <div
                         class="absolute z-[100] scale-0 transition-all duration-100 origin-top transform
-                            group-hover:scale-100 w-[220px] left-1/2 -translate-x-1/2 top-5 rounded-md shadow-lg bg-white
+                            group-hover:scale-100 w-[220px] left-1/2 -translate-x-1/4 top-5 rounded-md shadow-lg bg-white
                             ring-1 ring-black ring-opacity-5 p-3 normal-case"
                     >
-                        <p class="text-xs text-gray-500 font-normal tracking-normal">
-                            Trust types come from the Estates Returns Information Collection (ERIC). Every trust is assigned a single type.
+                        <p class="text-sm text-gray-500 font-normal tracking-normal">
+                            Trust type is a classification of NHS trusts by the kind of services they provide, such as Acute, Mental Health, Community, or Ambulance. Every trust has a single type.
                             See <a href="/faq/#how-are-trust-types-determined" class="underline font-semibold" target="_blank">the FAQs</a> for more details.
                         </p>
                     </div>
@@ -636,7 +636,7 @@
                             group-hover:scale-100 w-[220px] left-1/2 -translate-x-1/2 top-5 rounded-md shadow-lg bg-white
                             ring-1 ring-black ring-opacity-5 p-3 normal-case"
                     >
-                        <p class="text-xs text-gray-500 font-normal tracking-normal">
+                        <p class="text-sm text-gray-500 font-normal tracking-normal">
                             Cancer Alliances are regional groupings for cancer care.
                             See <a href="/faq/#where-do-cancer-alliance-boundaries-come-from" class="underline font-semibold" target="_blank">the FAQs</a> for more details.
                         </p>
@@ -721,7 +721,7 @@
                             group-hover:scale-100 w-[220px] left-1/2 -translate-x-1/2 top-5 rounded-md shadow-lg bg-white
                             ring-1 ring-black ring-opacity-5 p-3 normal-case"
                     >
-                        <p class="text-xs text-gray-500 font-normal tracking-normal">
+                        <p class="text-sm text-gray-500 font-normal tracking-normal">
                             The Shelford Group is a collaboration of ten large teaching and research NHS hospital trusts in England.
                             See <a href="/faq/#what-is-the-shelford-group" class="underline font-semibold" target="_blank">the FAQs</a> for more details.
                         </p>

--- a/src/components/common/TrustScopePanel.svelte
+++ b/src/components/common/TrustScopePanel.svelte
@@ -21,11 +21,9 @@
     export let resetKey = undefined;
     export let enableScopeSelection = false;
     export let selectedScope = 'all';
-    export let singleTrust = undefined;
 
     const SCOPE_ALL = 'all';
     const SCOPE_NATIONAL = 'national';
-    const SCOPE_TRUST = 'trust';
     const SCOPE_GROUP = 'group';
 
     function normaliseAcuteSelection(types) {
@@ -267,7 +265,7 @@
             {/if}
         </div>
     {/if}
-    <div class="flex-1 py-2 {enableScopeSelection && (selectedScope === SCOPE_TRUST || selectedScope === SCOPE_GROUP) ? 'overflow-visible' : 'overflow-y-auto max-h-[min(70vh,400px)]'}">
+    <div class="flex-1 py-2 {enableScopeSelection && selectedScope === SCOPE_GROUP ? 'overflow-visible' : 'overflow-y-auto max-h-[min(70vh,400px)]'}">
         {#if enableScopeSelection}
             <div class="px-2 pb-2">
                 <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm transition-colors mx-1 min-h-[44px] sm:min-h-0 {selectedScope === SCOPE_ALL ? 'text-oxford-700' : 'text-gray-700'}">
@@ -296,21 +294,6 @@
                         {totalTrustCount} trusts
                     </span>
                 </label>
-                <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm transition-colors mx-1 min-h-[44px] sm:min-h-0 {selectedScope === SCOPE_TRUST ? 'text-oxford-700' : 'text-gray-700'}">
-                    <input
-                        type="radio"
-                        name="trust-scope-selection"
-                        checked={selectedScope === SCOPE_TRUST}
-                        on:change={() => selectScope(SCOPE_TRUST)}
-                        class="border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
-                    />
-                    <span class="flex-1 min-w-0">Single trust</span>
-                </label>
-                {#if selectedScope === SCOPE_TRUST && singleTrust}
-                    <div class="mx-1 mb-1 min-w-0">
-                        {@render singleTrust()}
-                    </div>
-                {/if}
                 <div class="mx-1 flex items-center gap-2 min-h-[44px] sm:min-h-0">
                     <label class="flex items-center gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm transition-colors flex-1 min-w-0 {selectedScope === SCOPE_GROUP ? 'text-oxford-700' : 'text-gray-700'}">
                         <input

--- a/src/components/common/TrustScopePanel.svelte
+++ b/src/components/common/TrustScopePanel.svelte
@@ -665,32 +665,34 @@
                 </button>
             </div>
             {#if !collapsedCancerAlliance}
-                {#each cancerAlliances as ca (ca.name)}
-                    <label class="flex flex-wrap items-start gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 min-w-0 w-full {selectedCancerAlliances.has(ca.name) ? 'text-oxford-700' : ''}">
+                <div class="max-h-48 overflow-y-auto">
+                    {#each cancerAlliances as ca (ca.name)}
+                        <label class="flex flex-wrap items-start gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 min-w-0 w-full {selectedCancerAlliances.has(ca.name) ? 'text-oxford-700' : ''}">
+                            <input
+                                type="checkbox"
+                                checked={selectedCancerAlliances.has(ca.name)}
+                                on:change={() => toggleCancerAlliance(ca.name)}
+                                class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
+                            />
+                            <span class="flex-1 min-w-0 break-words" title={ca.name}>{cancerAllianceDisplayName(ca.name)}</span>
+                            <span class="text-[10px] font-medium text-gray-400 whitespace-normal text-right tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
+                                {(source.getOrgsByCancerAlliance(ca.name) || []).length} trusts
+                            </span>
+                        </label>
+                    {/each}
+                    <label class="flex flex-wrap items-start gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 border-t border-gray-100 mt-1 pt-1.5 min-w-0 w-full {selectedCancerAlliances.has(CANCER_ALLIANCE_NA) ? 'text-oxford-700' : ''}">
                         <input
                             type="checkbox"
-                            checked={selectedCancerAlliances.has(ca.name)}
-                            on:change={() => toggleCancerAlliance(ca.name)}
+                            checked={selectedCancerAlliances.has(CANCER_ALLIANCE_NA)}
+                            on:change={() => toggleCancerAlliance(CANCER_ALLIANCE_NA)}
                             class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
                         />
-                        <span class="flex-1 min-w-0 break-words" title={ca.name}>{cancerAllianceDisplayName(ca.name)}</span>
+                        <span class="flex-1 min-w-0 break-words" title="Trusts not associated with a Cancer Alliance">{cancerAllianceDisplayName(CANCER_ALLIANCE_NA)}</span>
                         <span class="text-[10px] font-medium text-gray-400 whitespace-normal text-right tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
-                            {(source.getOrgsByCancerAlliance(ca.name) || []).length} trusts
+                            {(source.getOrgsWithNoCancerAlliance() || []).length} trusts
                         </span>
                     </label>
-                {/each}
-                <label class="flex flex-wrap items-start gap-2.5 cursor-pointer hover:bg-gray-50 rounded-lg px-2 py-2 sm:py-1.5 text-sm text-gray-700 transition-colors mx-1 min-h-[44px] sm:min-h-0 border-t border-gray-100 mt-1 pt-1.5 min-w-0 w-full {selectedCancerAlliances.has(CANCER_ALLIANCE_NA) ? 'text-oxford-700' : ''}">
-                    <input
-                        type="checkbox"
-                        checked={selectedCancerAlliances.has(CANCER_ALLIANCE_NA)}
-                        on:change={() => toggleCancerAlliance(CANCER_ALLIANCE_NA)}
-                        class="rounded border-gray-300 text-oxford-600 focus:ring-oxford-500 focus:ring-offset-0 w-4 h-4 shrink-0"
-                    />
-                    <span class="flex-1 min-w-0 break-words" title="Trusts not associated with a Cancer Alliance">{cancerAllianceDisplayName(CANCER_ALLIANCE_NA)}</span>
-                    <span class="text-[10px] font-medium text-gray-400 whitespace-normal text-right tabular-nums bg-gray-100/80 px-1.5 py-0.5 rounded">
-                        {(source.getOrgsWithNoCancerAlliance() || []).length} trusts
-                    </span>
-                </label>
+                </div>
             {/if}
         </div>
     {/if}

--- a/viewer/content/faq/05_analyse.md
+++ b/viewer/content/faq/05_analyse.md
@@ -16,17 +16,17 @@ The scope of an analysis specifies which NHS trusts are included and the level o
 
 - **All trusts**: Includes all NHS trusts in the analysis. This gives access to trust-level charts and tables, as well as ICB, regional, and national breakdowns, and trust-level percentile charts. To compare one trust with national variation, select that trust in the results and turn on percentiles.
 - **National**: Shows nationally aggregated totals only. Trust-level, ICB, and regional breakdowns are not available. Use this when you only need a national total for the selected products.
-- **Trust group**: Restricts the analysis to a group of NHS trusts defined by filters such as [trust type](/faq/#how-are-trust-types-determined), region, ICB, [Cancer Alliance](/faq/#where-do-cancer-alliance-boundaries-come-from), or [Shelford Group](/faq/#what-is-the-shelford-group) membership. Results and comparisons (including percentiles, where available) are based on the trusts in that group.
+- **Filtered trusts**: Restricts the analysis to NHS trusts defined by filters such as [trust type](/faq/#how-are-trust-types-determined), region, ICB, [Cancer Alliance](/faq/#where-do-cancer-alliance-boundaries-come-from), or [Shelford Group](/faq/#what-is-the-shelford-group) membership. Results and comparisons (including percentiles, where available) are based on those trusts.
 
 See also [which NHS trusts are included](/faq/#which-nhs-trusts-are-included).
 
 ### How do I see ICB, regional, and national breakdowns?
 
-To view ICB, regional, and national analysis breakdowns, as well as trust-level variation as a percentiles chart, choose the **All trusts** or **Trust group** scope in the analysis builder. With **Trust group**, these breakdowns only include the trusts in the scope for this analysis (for example, regional totals across acute trusts only), not all trusts in England. Percentile charts are available when the filtered group is large enough. See [What is analysis scope?](/faq/#what-is-analysis-scope).
+To view ICB, regional, and national analysis breakdowns, as well as trust-level variation as a percentiles chart, choose the **All trusts** or **Filtered trusts** scope in the analysis builder. With **Filtered trusts**, these breakdowns only include the trusts in the scope for this analysis (for example, regional totals across acute trusts only), not all trusts in England. Percentile charts are available when the filtered set is large enough. See [What is analysis scope?](/faq/#what-is-analysis-scope).
 
 ### How do I restrict an analysis to a specific set of NHS Trusts?
 
-To restrict an analysis to a specific set of NHS Trusts, use **Trust group** to filter trusts by attributes such as [trust type](/faq/#how-are-trust-types-determined), region, or ICB. To highlight one trust within a wider cohort, choose **All trusts** or **Trust group**, then select that trust in the results. See [What is analysis scope?](/faq/#what-is-analysis-scope).
+To restrict an analysis to a specific set of NHS Trusts, use **Filtered trusts** to filter by attributes such as [trust type](/faq/#how-are-trust-types-determined), region, or ICB. To highlight one trust within a wider cohort, choose **All trusts** or **Filtered trusts**, then select that trust in the results. See [What is analysis scope?](/faq/#what-is-analysis-scope).
 
 ### What is SCMD quantity?
 

--- a/viewer/content/faq/05_analyse.md
+++ b/viewer/content/faq/05_analyse.md
@@ -14,9 +14,8 @@ There is no quantity reported when a trust has not issued a product or the selec
 
 The scope of an analysis specifies which NHS trusts are included and the level of reporting available in the results. You choose a scope in the analysis builder. The options are:
 
-- **All trusts**: Includes all NHS trusts in the analysis. This gives access to trust-level charts and tables, as well as ICB, regional, and national breakdowns, and trust-level percentile charts.
+- **All trusts**: Includes all NHS trusts in the analysis. This gives access to trust-level charts and tables, as well as ICB, regional, and national breakdowns, and trust-level percentile charts. To compare one trust with national variation, select that trust in the results and turn on percentiles.
 - **National**: Shows nationally aggregated totals only. Trust-level, ICB, and regional breakdowns are not available. Use this when you only need a national total for the selected products.
-- **Single trust**: Restricts the analysis to one NHS trust that you select. Results show data for that trust only.
 - **Trust group**: Restricts the analysis to a group of NHS trusts defined by filters such as [trust type](/faq/#how-are-trust-types-determined), region, ICB, [Cancer Alliance](/faq/#where-do-cancer-alliance-boundaries-come-from), or [Shelford Group](/faq/#what-is-the-shelford-group) membership. Results and comparisons (including percentiles, where available) are based on the trusts in that group.
 
 See also [which NHS trusts are included](/faq/#which-nhs-trusts-are-included).
@@ -27,7 +26,7 @@ To view ICB, regional, and national analysis breakdowns, as well as trust-level 
 
 ### How do I restrict an analysis to a specific set of NHS Trusts?
 
-To restrict an analysis to a specific set of NHS Trusts, use **Single trust** to select one trust, or **Trust group** to filter trusts by attributes such as [trust type](/faq/#how-are-trust-types-determined), region, or ICB. See [What is analysis scope?](/faq/#what-is-analysis-scope).
+To restrict an analysis to a specific set of NHS Trusts, use **Trust group** to filter trusts by attributes such as [trust type](/faq/#how-are-trust-types-determined), region, or ICB. To highlight one trust within a wider cohort, choose **All trusts** or **Trust group**, then select that trust in the results. See [What is analysis scope?](/faq/#what-is-analysis-scope).
 
 ### What is SCMD quantity?
 


### PR DESCRIPTION
- Drop the single-trust analysis scope. This can be done through all trusts scope.
- Rename **Trust group** to **Filtered trusts**, and redesign the scope picker as selectable rows with clearer helper text (including marking **All trusts** as the default).
- Improve the filtered-trusts UI: show the matched trust count and **Clear selection** in the row, add per-filter selection badges, clarify tooltips, and make the Cancer Alliance list scrollable.
- Make filtered-scope chart and table copy clearer: labelled filter descriptions, bold trust counts and filters, and consistent in-scope wording across modes.